### PR TITLE
Add simplification project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 /jsplat-experiments
 /jsplat-experiments-tilesets
+/jsplat-examples-gltf
 
 /jsplat-examples/target
 /jsplat-examples/.project
@@ -68,3 +69,8 @@
 /jsplat-processing/.project
 /jsplat-processing/.settings
 /jsplat-processing/.classpath
+
+/jsplat-simplification/target
+/jsplat-simplification/.project
+/jsplat-simplification/.settings
+/jsplat-simplification/.classpath

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Java libraries for Gaussian splats.
   - [`jsplat-io-gltf-spz`](./jsplat-io-gltf-spz) - glTF with [`KHR_spz_gaussian_splatting_compression_spz_2`](https://github.com/KhronosGroup/glTF/pull/2531)
   - [`jsplat-io-sog`](./jsplat-io-sog) - [SOG Format](https://developer.playcanvas.com/user-manual/gaussian-splatting/formats/sog/), with a basic reader and an **experimental** (and slow) writer.
 - [`jsplat-processing`](./jsplat-processing) - Experimental library for basic processing operations on splats
+- [`jsplat-simplification`](./jsplat-simplification) - Experimental library for basic simplification of splat data sets. Note that some classes in this package have been ported from https://github.com/saliteta/NanoGS, so the license of this package is [CC BY-NC 4.0](./jsplat-simplification/NanoGS-LICENSE.txt)
 
 A basic viewer implementation can be found in [`jsplat-viewer`](./jsplat-viewer),
 with the actual implementation based on LWJGL in [`jsplat-viewer-lwjgl`](./jsplat-viewer-lwjgl).

--- a/jsplat-app/pom.xml
+++ b/jsplat-app/pom.xml
@@ -20,6 +20,11 @@
 		</dependency>
 		<dependency>
 			<groupId>de.javagl</groupId>
+			<artifactId>jsplat-simplification</artifactId>
+			<version>0.0.1-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>de.javagl</groupId>
 			<artifactId>jsplat-io-gsplat</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
@@ -43,13 +48,11 @@
 			<artifactId>jsplat-io-gltf</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
-		<!-- Omitted for release 
 		<dependency>
 			<groupId>de.javagl</groupId>
 			<artifactId>jsplat-io-sog</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
-	     -->
 		<dependency>
 			<groupId>de.javagl</groupId>
 			<artifactId>jsplat-viewer</artifactId>

--- a/jsplat-app/src/main/java/de/javagl/jsplat/app/DataSet.java
+++ b/jsplat-app/src/main/java/de/javagl/jsplat/app/DataSet.java
@@ -114,6 +114,16 @@ class DataSet
     }
     
     /**
+     * Returns the name of this data set
+     * 
+     * @return The name
+     */
+    String getName()
+    {
+        return name;
+    }
+    
+    /**
      * Returns the SH degree of the splats
      * 
      * @return The degree

--- a/jsplat-app/src/main/java/de/javagl/jsplat/app/DataSet.java
+++ b/jsplat-app/src/main/java/de/javagl/jsplat/app/DataSet.java
@@ -98,7 +98,7 @@ class DataSet
     void setTransform(Transform transform)
     {
         this.currentTransform = transform;
-        float[] matrix = Transforms.toMatrix(transform);
+        double[] matrix = Transforms.toMatrix(transform);
         int shDimensions = Splats.dimensionsForDegree(shDegree);
         Consumer<MutableSplat> t =
             SplatTransforms.createTransform(matrix, shDimensions);

--- a/jsplat-app/src/main/java/de/javagl/jsplat/app/DataSetsPanel.java
+++ b/jsplat-app/src/main/java/de/javagl/jsplat/app/DataSetsPanel.java
@@ -27,13 +27,10 @@
 package de.javagl.jsplat.app;
 
 import java.awt.BorderLayout;
-import java.awt.FlowLayout;
 import java.util.AbstractList;
 import java.util.List;
-import java.util.function.Consumer;
 
 import javax.swing.DefaultListModel;
-import javax.swing.JButton;
 import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -61,16 +58,9 @@ class DataSetsPanel extends JPanel
     private DefaultListModel<DataSet> listModel;
     
     /**
-     * The button to remove the selected data set
-     */
-    private JButton removeSelectedButton;
-    
-    /**
      * Creates a new instance
-     * 
-     * @param removalCallback A callback that will receive removed data sets
      */
-    DataSetsPanel(Consumer<DataSet> removalCallback)
+    DataSetsPanel()
     {
         super(new BorderLayout());
         listModel = new DefaultListModel<DataSet>();
@@ -78,18 +68,6 @@ class DataSetsPanel extends JPanel
         list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         JScrollPane scrollPane = new JScrollPane(list);
         add(scrollPane, BorderLayout.CENTER);
-        
-        JPanel p = new JPanel(new FlowLayout());
-        removeSelectedButton = new JButton("Remove");
-        removeSelectedButton.setEnabled(false);
-        removeSelectedButton.addActionListener(e ->
-        {
-            DataSet removedDataSet = getSelectedDataSet();
-            removeDataSet(removedDataSet);
-            removalCallback.accept(removedDataSet);
-        });
-        p.add(removeSelectedButton);
-        add(p, BorderLayout.SOUTH);
     }
     
     /**
@@ -111,7 +89,6 @@ class DataSetsPanel extends JPanel
     {
         listModel.addElement(dataSet);
         list.setSelectedIndex(listModel.size() - 1);
-        removeSelectedButton.setEnabled(true);
     }
     
     /**
@@ -130,10 +107,6 @@ class DataSetsPanel extends JPanel
         else
         {
             list.setSelectedIndex(oldIndex - 1);
-        }
-        if (listModel.getSize() == 0)
-        {
-            removeSelectedButton.setEnabled(false);
         }
     }
     

--- a/jsplat-app/src/main/java/de/javagl/jsplat/app/JSplatApplication.java
+++ b/jsplat-app/src/main/java/de/javagl/jsplat/app/JSplatApplication.java
@@ -71,6 +71,8 @@ import de.javagl.jsplat.io.gsplat.GsplatSplatWriter;
 import de.javagl.jsplat.io.ply.PlySplatReader;
 import de.javagl.jsplat.io.ply.PlySplatWriter;
 import de.javagl.jsplat.io.ply.PlySplatWriter.PlyFormat;
+import de.javagl.jsplat.io.sog.SogSplatReader;
+import de.javagl.jsplat.io.sog.SogSplatWriter;
 import de.javagl.jsplat.io.spz.SpzSplatReader;
 import de.javagl.jsplat.io.spz.SpzSplatWriter;
 import de.javagl.swing.tasks.SwingTask;
@@ -424,10 +426,10 @@ class JSplatApplication
         {
             return new GlbSplatListReader();
         }
-        /*
-         * Omitted for release if (name.endsWith("sog")) { return new
-         * SogSplatReader(); }
-         */
+        if (name.endsWith("sog"))
+        {
+            return new SogSplatReader();
+        }
         if (name.endsWith("gltf"))
         {
             logger.warning("Assuming glTF file to be embedded");
@@ -512,10 +514,10 @@ class JSplatApplication
             }
             return new GltfSplatWriter();
         }
-        /*
-         * Omitted for release if (name.endsWith("sog")) { return new
-         * SogSplatWriter(); }
-         */
+        if (name.endsWith("sog"))
+        {
+            return new SogSplatWriter();
+        }
         logger.warning(
             "Could not determine type from file name for '" + fileName + "'");
         return null;

--- a/jsplat-app/src/main/java/de/javagl/jsplat/app/JSplatApplicationPanel.java
+++ b/jsplat-app/src/main/java/de/javagl/jsplat/app/JSplatApplicationPanel.java
@@ -33,10 +33,10 @@ import java.awt.GridLayout;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
 
@@ -55,8 +55,12 @@ import de.javagl.common.ui.panel.collapsible.AccordionPanel;
 import de.javagl.jsplat.MutableSplat;
 import de.javagl.jsplat.Splat;
 import de.javagl.jsplat.Splats;
+import de.javagl.jsplat.simplification.Simplifier;
+import de.javagl.jsplat.simplification.Simplifiers;
 import de.javagl.jsplat.viewer.SplatViewer;
 import de.javagl.jsplat.viewer.SplatViewers;
+import de.javagl.swing.tasks.SwingTask;
+import de.javagl.swing.tasks.SwingTaskExecutors;
 
 /**
  * The main panel for the JSplat application
@@ -83,7 +87,7 @@ class JSplatApplicationPanel extends JPanel
      * Whether the camera should be fit to a loaded data set.
      */
     private boolean doFit;
-    
+
     /**
      * A label for status messages
      */
@@ -93,12 +97,17 @@ class JSplatApplicationPanel extends JPanel
      * The spinner for the FOV
      */
     private JSpinner fovDegYSpinner;
-    
+
     /**
      * The panel containing the list of data sets
      */
     private DataSetsPanel dataSetsPanel;
-    
+
+    /**
+     * The panel containing editing controls for the data sets
+     */
+    private JPanel dataSetsEditingPanel;
+
     /**
      * The panel for controlling the transforms
      */
@@ -110,10 +119,10 @@ class JSplatApplicationPanel extends JPanel
     JSplatApplicationPanel()
     {
         super(new BorderLayout());
-        
+
         JSplitPane mainSplitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
         add(mainSplitPane, BorderLayout.CENTER);
-        
+
         this.splatViewer = SplatViewers.createDefault();
         if (this.splatViewer == null)
         {
@@ -122,7 +131,7 @@ class JSplatApplicationPanel extends JPanel
         }
         else
         {
-            JPanel container = new JPanel(new GridLayout(1,1));
+            JPanel container = new JPanel(new GridLayout(1, 1));
             Component renderComponent = splatViewer.getRenderComponent();
             renderComponent.setMinimumSize(new Dimension(10, 10));
             container.add(renderComponent);
@@ -135,10 +144,10 @@ class JSplatApplicationPanel extends JPanel
 
         statusLabel = new JLabel(" ");
         add(statusLabel, BorderLayout.SOUTH);
-        
+
         doFit = true;
     }
-    
+
     /**
      * Create the control panel
      * 
@@ -147,19 +156,20 @@ class JSplatApplicationPanel extends JPanel
     private JPanel createControlPanel()
     {
         JPanel p = new JPanel(new BorderLayout());
-        
+
         AccordionPanel accordionPanel = new AccordionPanel();
-        
+
         accordionPanel.addToAccordion("Camera", createCameraPanel());
         accordionPanel.addToAccordion("Dummy data sets",
             createDummyDataSetsPanel());
         accordionPanel.addToAccordion("Data sets", createDataSetsPanel());
+        accordionPanel.addToAccordion("Edit", createDataSetsEditingPanel());
         accordionPanel.addToAccordion("Transform", createTransformPanel());
 
         p.add(accordionPanel, BorderLayout.CENTER);
         return p;
     }
-    
+
     /**
      * Create the camera panel
      * 
@@ -168,7 +178,7 @@ class JSplatApplicationPanel extends JPanel
     private JPanel createCameraPanel()
     {
         JPanel p = new JPanel(new GridLayout(0, 1));
-        
+
         JButton resetButton = new JButton("Reset camera");
         resetButton.addActionListener(e ->
         {
@@ -192,7 +202,7 @@ class JSplatApplicationPanel extends JPanel
         });
         p.add(fitButton);
         p.add(createFovDegYSpinnerPanel());
-        
+
         return p;
     }
 
@@ -219,10 +229,10 @@ class JSplatApplicationPanel extends JPanel
         });
         JSpinners.setSpinnerDraggingEnabled(fovDegYSpinner, true);
         p.add(fovDegYSpinner, BorderLayout.CENTER);
-        
+
         return p;
     }
-    
+
     /**
      * Returns the current FOV selected in the spinner
      * 
@@ -234,7 +244,7 @@ class JSplatApplicationPanel extends JPanel
         Number number = (Number) value;
         float f = number.floatValue();
         return f;
-        
+
     }
 
     /**
@@ -245,13 +255,13 @@ class JSplatApplicationPanel extends JPanel
     private JPanel createDummyDataSetsPanel()
     {
         JPanel p = new JPanel(new GridLayout(0, 1));
-        
+
         p.add(createButton("unitCube", UnitCubeSplats::create));
         p.add(createButton("unitSh", UnitShSplats::create));
-        
+
         return p;
     }
-    
+
     /**
      * Create a button with the given text to set the splats provided by the
      * given supplier into the viewer
@@ -270,7 +280,7 @@ class JSplatApplicationPanel extends JPanel
         });
         return button;
     }
-    
+
     /**
      * Create the data sets panel
      * 
@@ -278,29 +288,157 @@ class JSplatApplicationPanel extends JPanel
      */
     private JPanel createDataSetsPanel()
     {
-        Consumer<DataSet> removalCallback = (removedDataSet) -> 
-        {
-            removeDataSet(removedDataSet);
-        };
-        this.dataSetsPanel = new DataSetsPanel(removalCallback);
-        dataSetsPanel.addSelectionListener((e) -> 
+        this.dataSetsPanel = new DataSetsPanel();
+
+        dataSetsPanel.addSelectionListener((e) ->
         {
             DataSet selectedDataSet = dataSetsPanel.getSelectedDataSet();
             if (selectedDataSet == null)
             {
+                GuiUtils.setDeepEnabled(dataSetsEditingPanel, false);
                 GuiUtils.setDeepEnabled(transformPanel, false);
                 return;
             }
+            GuiUtils.setDeepEnabled(dataSetsEditingPanel, true);
             GuiUtils.setDeepEnabled(transformPanel, true);
             Transform transform = selectedDataSet.getTransform();
             transformPanel.setTransform(transform);
         });
         return dataSetsPanel;
     }
-    
+
+    /**
+     * Create the panel with the controls for editing data sets
+     * 
+     * @return The panel
+     */
+    private JPanel createDataSetsEditingPanel()
+    {
+        this.dataSetsEditingPanel = new JPanel(new GridLayout(0, 1));
+
+        JButton removeSelectedButton = new JButton("Remove");
+        removeSelectedButton.addActionListener(e ->
+        {
+            DataSet removedDataSet = dataSetsPanel.getSelectedDataSet();
+            dataSetsPanel.removeDataSet(removedDataSet);
+            removeDataSet(removedDataSet);
+        });
+        dataSetsEditingPanel.add(removeSelectedButton);
+
+        JPanel simplifyPanel = createSimplifyPanel();
+        dataSetsEditingPanel.add(simplifyPanel);
+
+        return dataSetsEditingPanel;
+    }
+
+    /**
+     * Create the panel with the controls for simplifying the selected data set
+     * 
+     * @return The panel
+     */
+    private JPanel createSimplifyPanel()
+    {
+        JPanel simplifyPanel = new JPanel(new BorderLayout());
+        JSpinner simplifySpinner =
+            new JSpinner(new SpinnerNumberModel(0.9, 0.01, 0.99, 0.01));
+        JSpinners.setSpinnerDraggingEnabled(simplifySpinner, true);
+        simplifyPanel.add(simplifySpinner, BorderLayout.CENTER);
+        JButton simplifyButton = new JButton("Simplify");
+        simplifyButton.addActionListener(e ->
+        {
+            DataSet originalDataSet = dataSetsPanel.getSelectedDataSet();
+
+            String originalName = originalDataSet.getName();
+            List<MutableSplat> originalSplats =
+                Splats.copyList(originalDataSet.getCurrentSplats());
+
+            Object v = simplifySpinner.getValue();
+            Number n = (Number) v;
+            float ratio = n.floatValue();
+
+            simplifyInBackground(originalName, originalSplats, ratio);
+
+        });
+        simplifyPanel.add(simplifyButton, BorderLayout.WEST);
+        return simplifyPanel;
+    }
+
+    /**
+     * Run the simplification of the given data set in a background task, and
+     * add the result as a new data set.
+     * 
+     * @param originalName The original name
+     * @param originalSplats The original splats
+     * @param ratio The simplification ratio
+     */
+    private void simplifyInBackground(String originalName,
+        List<? extends Splat> originalSplats, float ratio)
+    {
+        class Task extends SwingTask<Void, Void>
+        {
+            private String simplifiedName;
+            private List<Splat> simplifiedSplats;
+
+            @Override
+            public Void doInBackground()
+            {
+                setProgress(-1.0);
+
+                String ratioString =
+                    String.format(Locale.ENGLISH, "%.2f", ratio);
+                simplifiedName = originalName + " (" + ratioString + ")";
+                simplifiedSplats = simplify(originalSplats, ratio);
+
+                return null;
+            }
+
+            @Override
+            protected void done()
+            {
+                super.done();
+
+                if (simplifiedSplats != null)
+                {
+                    addSplatLists(Arrays.asList(simplifiedName),
+                        Arrays.asList(simplifiedSplats));
+                }
+            }
+        }
+        Task task = new Task();
+        SwingTaskExecutors.create(task).setDialogUncaughtExceptionHandler()
+            .setTitle("Simplifying...").build().execute();
+    }
+
+    /**
+     * Simplify the given splats with the given ratio and return the result
+     * 
+     * @param splats The original splats
+     * @param ratio The simplification ratio
+     * @return The result
+     */
+    private static List<Splat> simplify(List<? extends Splat> splats,
+        float ratio)
+    {
+        String ratioString = String.format(Locale.ENGLISH, "%.2f", ratio);
+        logger.info("Simplifying " + splats.size() + " splats with a ratio of "
+            + ratioString);
+
+        Simplifier simplifier = Simplifiers.createNanoGs();
+        long beforeNs = System.nanoTime();
+
+        List<Splat> simplifiedSplats = simplifier.simplify(splats, ratio);
+
+        long afterNs = System.nanoTime();
+        double ms = (afterNs - beforeNs) / 1e6;
+        logger.info("Simplifying " + splats.size() + " splats with a ratio of "
+            + ratioString + " resulted in " + simplifiedSplats.size()
+            + " splats and took " + ms + " ms");
+        return simplifiedSplats;
+    }
+
     /**
      * Create the transform panel
-     *  
+     * 
      * @return The panel
      */
     private JPanel createTransformPanel()
@@ -363,7 +501,7 @@ class JSplatApplicationPanel extends JPanel
             doFit = false;
         }
         updateStatus();
-    }    
+    }
 
     /**
      * Add the splats that should be displayed
@@ -376,7 +514,7 @@ class JSplatApplicationPanel extends JPanel
         addSplatLists(Collections.singletonList(name),
             Collections.singletonList(splats));
     }
-    
+
     /**
      * Update the status label
      */
@@ -440,8 +578,8 @@ class JSplatApplicationPanel extends JPanel
      * @param splats The splats
      * @return The bounding box
      */
-    private static float[] computeMinMax(
-        Iterable<? extends Iterable<? extends Splat>> splats)
+    private static float[]
+        computeMinMax(Iterable<? extends Iterable<? extends Splat>> splats)
     {
         float minMax[] = new float[]
         { Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY,
@@ -465,8 +603,8 @@ class JSplatApplicationPanel extends JPanel
     /**
      * Returns a list of all current splats.
      * 
-     * Note: This may be a bit costly and memory-consuming. It is only 
-     * intended for splats that are about to be saved to a file.
+     * Note: This may be a bit costly and memory-consuming. It is only intended
+     * for splats that are about to be saved to a file.
      * 
      * @return The list of all splats
      */

--- a/jsplat-app/src/main/java/de/javagl/jsplat/app/JSplatApplicationPanel.java
+++ b/jsplat-app/src/main/java/de/javagl/jsplat/app/JSplatApplicationPanel.java
@@ -390,7 +390,7 @@ class JSplatApplicationPanel extends JPanel
             allSplats.add(dataSet.getCurrentSplats());
         }
         int count = allSplats.stream().mapToInt(t -> t.size()).sum();
-        float minMax[] = computeMinMax(allSplats);
+        double minMax[] = computeMinMax(allSplats);
         String b = boundsToString(minMax);
         statusLabel.setText(count + " splats, bounds: " + b);
     }
@@ -423,7 +423,7 @@ class JSplatApplicationPanel extends JPanel
      * @param minMax The bounds
      * @return The string
      */
-    private static String boundsToString(float minMax[])
+    private static String boundsToString(double minMax[])
     {
         DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.ENGLISH);
         DecimalFormat df = new DecimalFormat("0.0###", symbols);
@@ -440,13 +440,13 @@ class JSplatApplicationPanel extends JPanel
      * @param splats The splats
      * @return The bounding box
      */
-    private static float[] computeMinMax(
-        Iterable<? extends Iterable<? extends Splat>> splats)
+    private static double[]
+        computeMinMax(Iterable<? extends Iterable<? extends Splat>> splats)
     {
-        float minMax[] = new float[]
-        { Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY,
-            Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY,
-            Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY };
+        double minMax[] = new double[]
+        { Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
+            Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY,
+            Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY };
         for (Iterable<? extends Splat> i : splats)
         {
             for (Splat s : i)

--- a/jsplat-app/src/main/java/de/javagl/jsplat/app/Transforms.java
+++ b/jsplat-app/src/main/java/de/javagl/jsplat/app/Transforms.java
@@ -41,16 +41,16 @@ class Transforms
      * @param t The transform
      * @return The matrix
      */
-    static float[] toMatrix(Transform t)
+    static double[] toMatrix(Transform t)
     {
-        float matrixX[] = VecMath.rotationX(t.rotationRadX, null);
-        float matrixY[] = VecMath.rotationY(t.rotationRadY, null);
-        float matrixZ[] = VecMath.rotationZ(t.rotationRadZ, null);
+        double matrixX[] = VecMath.rotationX(t.rotationRadX, null);
+        double matrixY[] = VecMath.rotationY(t.rotationRadY, null);
+        double matrixZ[] = VecMath.rotationZ(t.rotationRadZ, null);
 
-        float scaleMatrix[] =
+        double scaleMatrix[] =
             VecMath.scale4x4(t.scaleX, t.scaleY, t.scaleZ, null);
 
-        float matrix[] = VecMath.identity4x4(null);
+        double matrix[] = VecMath.identity4x4(null);
         VecMath.mul4x4(matrix, matrixX, matrix);
         VecMath.mul4x4(matrix, matrixY, matrix);
         VecMath.mul4x4(matrix, matrixZ, matrix);

--- a/jsplat-examples/src/main/java/de/javagl/jsplat/examples/JSplatGltfRoundtripExperiments.java
+++ b/jsplat-examples/src/main/java/de/javagl/jsplat/examples/JSplatGltfRoundtripExperiments.java
@@ -44,7 +44,7 @@ public class JSplatGltfRoundtripExperiments
         
         // The huge epsilon is required for the 'scales', where a value
         // of 0.1 becomes 0.125 due to quantization
-        float epsilon = 0.03f;
+        double epsilon = 0.03;
         for (int i=0; i<splatsA.size(); i++)
         {
             Splat splatA = splatsA.get(i);

--- a/jsplat-examples/src/main/java/de/javagl/jsplat/examples/JSplatRoundtripTests.java
+++ b/jsplat-examples/src/main/java/de/javagl/jsplat/examples/JSplatRoundtripTests.java
@@ -37,9 +37,9 @@ public class JSplatRoundtripTests
      */
     public static void main(String[] args) throws IOException
     {
-        runTestWith(GltfSplatWriter::new, GltfSplatReader::new, 1e-6f);
-        runTestWith(SpzSplatWriter::new, SpzSplatReader::new, 0.08f);
-        runTestWith(GltfSpzSplatWriter::new, GltfSpzSplatReader::new, 0.08f);
+        runTestWith(GltfSplatWriter::new, GltfSplatReader::new, 1e-6);
+        runTestWith(SpzSplatWriter::new, SpzSplatReader::new, 0.08);
+        runTestWith(GltfSpzSplatWriter::new, GltfSpzSplatReader::new, 0.08);
     }
 
     /**
@@ -54,7 +54,7 @@ public class JSplatRoundtripTests
      * @throws IOException If an IO error occurs
      */
     private static void runTestWith(Supplier<? extends SplatListWriter> ws,
-        Supplier<? extends SplatListReader> rs, float epsilon)
+        Supplier<? extends SplatListReader> rs, double epsilon)
         throws IOException
     {
         int numSplats = 1;
@@ -118,31 +118,31 @@ public class JSplatRoundtripTests
      * @param offset An offset for the values
      * @return The splat
      */
-    static MutableSplat createDummySplat(float offset)
+    static MutableSplat createDummySplat(double offset)
     {
         MutableSplat s = Splats.create(3);
-        s.setPositionX(offset + 1.1f);
-        s.setPositionY(offset + 1.2f);
-        s.setPositionZ(offset + 1.3f);
+        s.setPositionX(offset + 1.1);
+        s.setPositionY(offset + 1.2);
+        s.setPositionZ(offset + 1.3);
 
-        s.setScaleX(offset + 2.1f);
-        s.setScaleY(offset + 2.2f);
-        s.setScaleZ(offset + 2.3f);
+        s.setScaleX(offset + 2.1);
+        s.setScaleY(offset + 2.2);
+        s.setScaleZ(offset + 2.3);
 
         // Some formats assume unit quaternions.
         // I'm looking at you, SPZ.
-        float rx = offset;
-        float ry = 0.2f;
-        float rz = 0.3f;
-        float rw = 0.4f;
-        float invLen =
-            1.0f / (float) Math.sqrt(rx * rx + ry * ry + rz * rz + rw * rw);
+        double rx = offset;
+        double ry = 0.2;
+        double rz = 0.3;
+        double rw = 0.4;
+        double invLen =
+            1.0f / Math.sqrt(rx * rx + ry * ry + rz * rz + rw * rw);
         s.setRotationX(rx * invLen);
         s.setRotationY(ry * invLen);
         s.setRotationZ(rz * invLen);
         s.setRotationW(rw * invLen);
 
-        s.setOpacity(offset + 4.1f);
+        s.setOpacity(offset + 4.1);
 
         // Some formats are performing a quantization on the
         // spherical harmonics components that assumes the
@@ -151,15 +151,15 @@ public class JSplatRoundtripTests
         int dims = s.getShDimensions();
         for (int i = 0; i < dims; i++)
         {
-            float index0 = (i * 3 + 0);
-            float index1 = (i * 3 + 1);
-            float index2 = (i * 3 + 2);
-            float a0 = (float)index0 / 47.0f;
-            float a1 = (float)index1 / 47.0f;
-            float a2 = (float)index2 / 47.0f;
-            float shx = -1.0f + a0 * 2.0f;
-            float shy = -1.0f + a1 * 2.0f;
-            float shz = -1.0f + a2 * 2.0f;
+            double index0 = (i * 3 + 0);
+            double index1 = (i * 3 + 1);
+            double index2 = (i * 3 + 2);
+            double a0 = index0 / 47.0;
+            double a1 = index1 / 47.0;
+            double a2 = index2 / 47.0;
+            double shx = -1.0 + a0 * 2.0;
+            double shy = -1.0 + a1 * 2.0;
+            double shz = -1.0 + a2 * 2.0;
             s.setShX(i, shx);
             s.setShY(i, shy);
             s.setShZ(i, shz);

--- a/jsplat-examples/src/main/java/de/javagl/jsplat/examples/JSplatRoundtrips.java
+++ b/jsplat-examples/src/main/java/de/javagl/jsplat/examples/JSplatRoundtrips.java
@@ -60,7 +60,7 @@ public class JSplatRoundtrips
 
         //roundtripAll("unitCube");
 
-        //float epsilon = 1e-5f;
+        //double epsilon = 1e-5;
         //verifySingle(SplatGrids.createRotations(), SplatFormat.PLY_ASCII, epsilon);
     }
 

--- a/jsplat-examples/src/main/java/de/javagl/jsplat/examples/SplatFilteringExample.java
+++ b/jsplat-examples/src/main/java/de/javagl/jsplat/examples/SplatFilteringExample.java
@@ -69,58 +69,58 @@ public class SplatFilteringExample
      */
     private static boolean allValuesValid(Splat splat)
     {
-        if (!Float.isFinite(splat.getPositionX()))
+        if (!Double.isFinite(splat.getPositionX()))
         {
             return false;
         }
 
-        if (!Float.isFinite(splat.getPositionY()))
+        if (!Double.isFinite(splat.getPositionY()))
         {
             return false;
         }
 
-        if (!Float.isFinite(splat.getPositionZ()))
+        if (!Double.isFinite(splat.getPositionZ()))
         {
             return false;
         }
 
-        if (!Float.isFinite(splat.getScaleX()))
+        if (!Double.isFinite(splat.getScaleX()))
         {
             return false;
         }
 
-        if (!Float.isFinite(splat.getScaleY()))
+        if (!Double.isFinite(splat.getScaleY()))
         {
             return false;
         }
 
-        if (!Float.isFinite(splat.getScaleZ()))
+        if (!Double.isFinite(splat.getScaleZ()))
         {
             return false;
         }
 
-        if (!Float.isFinite(splat.getRotationX()))
+        if (!Double.isFinite(splat.getRotationX()))
         {
             return false;
         }
 
-        if (!Float.isFinite(splat.getRotationY()))
+        if (!Double.isFinite(splat.getRotationY()))
         {
             return false;
         }
 
-        if (!Float.isFinite(splat.getRotationZ()))
+        if (!Double.isFinite(splat.getRotationZ()))
         {
             return false;
         }
 
-        if (!Float.isFinite(splat.getRotationW()))
+        if (!Double.isFinite(splat.getRotationW()))
         {
             return false;
         }
 
         // Note: The opacity may be infinite! (But not NaN)
-        if (Float.isNaN(splat.getOpacity()))
+        if (Double.isNaN(splat.getOpacity()))
         {
             return false;
         }
@@ -128,15 +128,15 @@ public class SplatFilteringExample
         int dims = splat.getShDimensions();
         for (int d = 0; d < dims; d++)
         {
-            if (!Float.isFinite(splat.getShX(d)))
+            if (!Double.isFinite(splat.getShX(d)))
             {
                 return false;
             }
-            if (!Float.isFinite(splat.getShY(d)))
+            if (!Double.isFinite(splat.getShY(d)))
             {
                 return false;
             }
-            if (!Float.isFinite(splat.getShZ(d)))
+            if (!Double.isFinite(splat.getShZ(d)))
             {
                 return false;
             }
@@ -155,19 +155,19 @@ public class SplatFilteringExample
         List<MutableSplat> splats = new ArrayList<MutableSplat>();
         for (int c = 0; c < 8; c++)
         {
-            float x = -0.5f + ((c & 1) == 0 ? 0.0f : 1.0f);
-            float y = -0.5f + ((c & 2) == 0 ? 0.0f : 1.0f);
-            float z = -0.5f + ((c & 4) == 0 ? 0.0f : 1.0f);
-            add(splats, 0, 100.0f, x, y, z);
+            double x = -0.5 + ((c & 1) == 0 ? 0.0 : 1.0);
+            double y = -0.5 + ((c & 2) == 0 ? 0.0 : 1.0);
+            double z = -0.5 + ((c & 4) == 0 ? 0.0 : 1.0);
+            add(splats, 0, 100.0, x, y, z);
         }
 
-        add(splats, 0, 100.0f, Float.NaN, 0.0f, 0.0f);
-        add(splats, 0, 100.0f, 0.0f, Float.NaN, 0.0f);
-        add(splats, 0, 100.0f, 0.0f, 0.0f, Float.NaN);
+        add(splats, 0, 100.0, Double.NaN, 0.0, 0.0);
+        add(splats, 0, 100.0, 0.0, Double.NaN, 0.0);
+        add(splats, 0, 100.0, 0.0, 0.0, Double.NaN);
 
-        add(splats, 0, 100.0f, Float.POSITIVE_INFINITY, 0.0f, 0.0f);
-        add(splats, 0, 100.0f, 0.0f, Float.POSITIVE_INFINITY, 0.0f);
-        add(splats, 0, 100.0f, 0.0f, 0.0f, Float.POSITIVE_INFINITY);
+        add(splats, 0, 100.0, Double.POSITIVE_INFINITY, 0.0, 0.0);
+        add(splats, 0, 100.0, 0.0, Double.POSITIVE_INFINITY, 0.0);
+        add(splats, 0, 100.0, 0.0, 0.0, Double.POSITIVE_INFINITY);
 
         return Collections.unmodifiableList(splats);
     }
@@ -182,8 +182,8 @@ public class SplatFilteringExample
      * @param npy The normalized position in y-direction
      * @param npz The normalized position in z-direction
      */
-    private static void add(List<MutableSplat> splats, int degree, float size,
-        float npx, float npy, float npz)
+    private static void add(List<MutableSplat> splats, int degree, double size,
+        double npx, double npy, double npz)
     {
         MutableSplat splat = Splats.create(degree);
 

--- a/jsplat-examples/src/main/java/de/javagl/jsplat/examples/SplatGridBuilder.java
+++ b/jsplat-examples/src/main/java/de/javagl/jsplat/examples/SplatGridBuilder.java
@@ -19,8 +19,8 @@ import de.javagl.jsplat.MutableSplat;
 public class SplatGridBuilder
 {
     /**
-     * Interface for classes that can receive an object and three floating
-     * point values
+     * Interface for classes that can receive an object and three double
+     * values
      * 
      * @param <T> The object type
      */
@@ -34,7 +34,7 @@ public class SplatGridBuilder
          * @param y The y value
          * @param z The z value
          */
-        void accept(T t, float x, float y, float z);
+        void accept(T t, double x, double y, double z);
     }
 
     /**
@@ -60,17 +60,17 @@ public class SplatGridBuilder
     /**
      * The consumers for the x-values
      */
-    private final List<BiConsumer<MutableSplat, Float>> consumersX;
+    private final List<BiConsumer<MutableSplat, Double>> consumersX;
 
     /**
      * The consumers for the y-values
      */
-    private final List<BiConsumer<MutableSplat, Float>> consumersY;
+    private final List<BiConsumer<MutableSplat, Double>> consumersY;
 
     /**
      * The consumers for the z-values
      */
-    private final List<BiConsumer<MutableSplat, Float>> consumersZ;
+    private final List<BiConsumer<MutableSplat, Double>> consumersZ;
 
     /**
      * The consumers for the 3D values
@@ -99,9 +99,9 @@ public class SplatGridBuilder
         this.sizeZ = sizeZ;
         this.supplier =
             Objects.requireNonNull(supplier, "The supplier may not be null");
-        this.consumersX = new ArrayList<BiConsumer<MutableSplat, Float>>();
-        this.consumersY = new ArrayList<BiConsumer<MutableSplat, Float>>();
-        this.consumersZ = new ArrayList<BiConsumer<MutableSplat, Float>>();
+        this.consumersX = new ArrayList<BiConsumer<MutableSplat, Double>>();
+        this.consumersY = new ArrayList<BiConsumer<MutableSplat, Double>>();
+        this.consumersZ = new ArrayList<BiConsumer<MutableSplat, Double>>();
         this.consumers3D = new ArrayList<Consumer3D<MutableSplat>>();
     }
 
@@ -110,7 +110,7 @@ public class SplatGridBuilder
      * 
      * @param consumer The consumer
      */
-    void registerX(BiConsumer<MutableSplat, Float> consumer)
+    void registerX(BiConsumer<MutableSplat, Double> consumer)
     {
         Objects.requireNonNull(consumer, "The consumer may not be null");
         consumersX.add(consumer);
@@ -121,7 +121,7 @@ public class SplatGridBuilder
      * 
      * @param consumer The consumer
      */
-    void registerY(BiConsumer<MutableSplat, Float> consumer)
+    void registerY(BiConsumer<MutableSplat, Double> consumer)
     {
         Objects.requireNonNull(consumer, "The consumer may not be null");
         consumersY.add(consumer);
@@ -132,7 +132,7 @@ public class SplatGridBuilder
      * 
      * @param consumer The consumer
      */
-    void registerZ(BiConsumer<MutableSplat, Float> consumer)
+    void registerZ(BiConsumer<MutableSplat, Double> consumer)
     {
         Objects.requireNonNull(consumer, "The consumer may not be null");
         consumersZ.add(consumer);
@@ -146,13 +146,13 @@ public class SplatGridBuilder
      * @param max The maximum
      * @param consumer The consumer
      */
-    public void registerX(float min, float max,
-        BiConsumer<MutableSplat, Float> consumer)
+    public void registerX(double min, double max,
+        BiConsumer<MutableSplat, Double> consumer)
     {
         Objects.requireNonNull(consumer, "The consumer may not be null");
         registerX((s, x) ->
         {
-            float fx = min + x * (max - min);
+            double fx = min + x * (max - min);
             consumer.accept(s, fx);
         });
     }
@@ -165,13 +165,13 @@ public class SplatGridBuilder
      * @param max The maximum
      * @param consumer The consumer
      */
-    public void registerY(float min, float max,
-        BiConsumer<MutableSplat, Float> consumer)
+    public void registerY(double min, double max,
+        BiConsumer<MutableSplat, Double> consumer)
     {
         Objects.requireNonNull(consumer, "The consumer may not be null");
         registerY((s, y) ->
         {
-            float fy = min + y * (max - min);
+            double fy = min + y * (max - min);
             consumer.accept(s, fy);
         });
     }
@@ -184,13 +184,13 @@ public class SplatGridBuilder
      * @param max The maximum
      * @param consumer The consumer
      */
-    public void registerZ(float min, float max,
-        BiConsumer<MutableSplat, Float> consumer)
+    public void registerZ(double min, double max,
+        BiConsumer<MutableSplat, Double> consumer)
     {
         Objects.requireNonNull(consumer, "The consumer may not be null");
         registerZ((s, z) ->
         {
-            float fz = min + z * (max - min);
+            double fz = min + z * (max - min);
             consumer.accept(s, fz);
         });
     }
@@ -220,20 +220,20 @@ public class SplatGridBuilder
             {
                 for (int z = 0; z < sizeZ; z++)
                 {
-                    float fx = 0.0f;
-                    float fy = 0.0f;
-                    float fz = 0.0f;
+                    double fx = 0.0;
+                    double fy = 0.0;
+                    double fz = 0.0;
                     if (sizeX > 1)
                     {
-                        fx = x / (float) (sizeX - 1);
+                        fx = (double)x / (sizeX - 1);
                     }
                     if (sizeY > 1)
                     {
-                        fy = y / (float) (sizeY - 1);
+                        fy = (double)y / (sizeY - 1);
                     }
                     if (sizeZ > 1)
                     {
-                        fz = z / (float) (sizeZ - 1);
+                        fz = (double)z / (sizeZ - 1);
                     }
 
                     MutableSplat s = generate(fx, fy, fz);
@@ -252,18 +252,18 @@ public class SplatGridBuilder
      * @param fz The z-coordinate
      * @return The splat
      */
-    private MutableSplat generate(float fx, float fy, float fz)
+    private MutableSplat generate(double fx, double fy, double fz)
     {
         MutableSplat s = supplier.get();
-        for (BiConsumer<MutableSplat, Float> consumer : consumersX)
+        for (BiConsumer<MutableSplat, Double> consumer : consumersX)
         {
             consumer.accept(s, fx);
         }
-        for (BiConsumer<MutableSplat, Float> consumer : consumersY)
+        for (BiConsumer<MutableSplat, Double> consumer : consumersY)
         {
             consumer.accept(s, fy);
         }
-        for (BiConsumer<MutableSplat, Float> consumer : consumersZ)
+        for (BiConsumer<MutableSplat, Double> consumer : consumersZ)
         {
             consumer.accept(s, fz);
         }

--- a/jsplat-examples/src/main/java/de/javagl/jsplat/examples/SplatGrids.java
+++ b/jsplat-examples/src/main/java/de/javagl/jsplat/examples/SplatGrids.java
@@ -34,10 +34,10 @@ public class SplatGrids
         };
         SplatGridBuilder g = new SplatGridBuilder(2, 2, 2, supplier);
 
-        float maxPosition = 100.0f;
-        g.registerX(0.0f, maxPosition, MutableSplat::setPositionX);
-        g.registerY(0.0f, maxPosition, MutableSplat::setPositionY);
-        g.registerZ(0.0f, maxPosition, MutableSplat::setPositionZ);
+        double maxPosition = 100.0;
+        g.registerX(0.0, maxPosition, MutableSplat::setPositionX);
+        g.registerY(0.0, maxPosition, MutableSplat::setPositionY);
+        g.registerZ(0.0, maxPosition, MutableSplat::setPositionZ);
 
         return g.generate();
     }
@@ -59,8 +59,8 @@ public class SplatGrids
      */
     public static List<MutableSplat> createBox(
         int pointsX, int pointsY, int pointsZ,
-        float minX, float minY, float minZ, 
-        float maxX, float maxY, float maxZ)
+        double minX, double minY, double minZ, 
+        double maxX, double maxY, double maxZ)
     {
         int shDegree = 0;
         Supplier<MutableSplat> supplier = () ->
@@ -99,15 +99,15 @@ public class SplatGrids
         };
         SplatGridBuilder g = new SplatGridBuilder(3, 3, 3, supplier);
 
-        float maxPosition = 100.0f;
-        g.registerX(0.0f, maxPosition, MutableSplat::setPositionX);
-        g.registerY(0.0f, maxPosition, MutableSplat::setPositionY);
-        g.registerZ(0.0f, maxPosition, MutableSplat::setPositionZ);
+        double maxPosition = 100.0;
+        g.registerX(0.0, maxPosition, MutableSplat::setPositionX);
+        g.registerY(0.0, maxPosition, MutableSplat::setPositionY);
+        g.registerZ(0.0, maxPosition, MutableSplat::setPositionZ);
 
-        float maxScale = 2.0f;
-        g.registerX(0.0f, maxScale, MutableSplat::setScaleX);
-        g.registerY(0.0f, maxScale, MutableSplat::setScaleY);
-        g.registerZ(0.0f, maxScale, MutableSplat::setScaleZ);
+        double maxScale = 2.0;
+        g.registerX(0.0, maxScale, MutableSplat::setScaleX);
+        g.registerY(0.0, maxScale, MutableSplat::setScaleY);
+        g.registerZ(0.0, maxScale, MutableSplat::setScaleZ);
 
         return g.generate();
     }
@@ -128,7 +128,7 @@ public class SplatGrids
         };
         SplatGridBuilder g = new SplatGridBuilder(9, 9, 9, supplier);
 
-        float maxPosition = 100.0f;
+        double maxPosition = 100.0;
         g.registerX(0.0f, maxPosition, MutableSplat::setPositionX);
         g.registerY(0.0f, maxPosition, MutableSplat::setPositionY);
         g.registerZ(0.0f, maxPosition, MutableSplat::setPositionZ);
@@ -137,15 +137,15 @@ public class SplatGrids
         g.registerY((s, y) -> s.setShY(0, Splats.colorToDirectCurrent(y)));
         g.registerZ((s, z) -> s.setShZ(0, Splats.colorToDirectCurrent(z)));
 
-        float minOpacity = -20.f;
-        float maxOpacity = 20.0f;
+        double minOpacity = -20.0;
+        double maxOpacity = 20.0;
         g.register((s, x, y, z) ->
         {
-            float dx = 0.5f - x;
-            float dy = 0.5f - y;
-            float dz = 0.5f - z;
-            float d = 1.0f - (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
-            float opacity = minOpacity + d * (maxOpacity - minOpacity);
+            double dx = 0.5 - x;
+            double dy = 0.5 - y;
+            double dz = 0.5 - z;
+            double d = 1.0 - Math.sqrt(dx * dx + dy * dy + dz * dz);
+            double opacity = minOpacity + d * (maxOpacity - minOpacity);
             s.setOpacity(opacity);
         });
 
@@ -168,10 +168,10 @@ public class SplatGrids
         };
         SplatGridBuilder g = new SplatGridBuilder(9, 9, 9, supplier);
 
-        float maxPosition = 100.0f;
-        g.registerX(0.0f, maxPosition, MutableSplat::setPositionX);
-        g.registerY(0.0f, maxPosition, MutableSplat::setPositionY);
-        g.registerZ(0.0f, maxPosition, MutableSplat::setPositionZ);
+        double maxPosition = 100.0;
+        g.registerX(0.0, maxPosition, MutableSplat::setPositionX);
+        g.registerY(0.0, maxPosition, MutableSplat::setPositionY);
+        g.registerZ(0.0, maxPosition, MutableSplat::setPositionZ);
 
         g.registerX((s, x) -> s.setShX(0, Splats.colorToDirectCurrent(x)));
         g.registerY((s, y) -> s.setShY(0, Splats.colorToDirectCurrent(y)));
@@ -196,15 +196,15 @@ public class SplatGrids
         };
         SplatGridBuilder g = new SplatGridBuilder(3, 3, 3, supplier);
 
-        float maxPosition = 100.0f;
-        g.registerX(0.0f, maxPosition, MutableSplat::setPositionX);
-        g.registerY(0.0f, maxPosition, MutableSplat::setPositionY);
-        g.registerZ(0.0f, maxPosition, MutableSplat::setPositionZ);
+        double maxPosition = 100.0f;
+        g.registerX(0.0, maxPosition, MutableSplat::setPositionX);
+        g.registerY(0.0, maxPosition, MutableSplat::setPositionY);
+        g.registerZ(0.0, maxPosition, MutableSplat::setPositionZ);
 
-        float maxScale = 2.0f;
-        g.registerX(0.0f, maxScale, MutableSplat::setScaleX);
-        g.registerY(0.0f, maxScale, MutableSplat::setScaleY);
-        g.registerZ(0.0f, maxScale, MutableSplat::setScaleZ);
+        double maxScale = 2.0;
+        g.registerX(0.0, maxScale, MutableSplat::setScaleX);
+        g.registerY(0.0, maxScale, MutableSplat::setScaleY);
+        g.registerZ(0.0, maxScale, MutableSplat::setScaleZ);
 
         g.registerX((s, x) -> s.setShX(0, Splats.colorToDirectCurrent(x)));
         g.registerY((s, y) -> s.setShY(0, Splats.colorToDirectCurrent(y)));
@@ -212,8 +212,8 @@ public class SplatGrids
 
         g.register((s, x, y, z) ->
         {
-            float max = Math.max(x, Math.max(y, z));
-            float angleRad = (float) (max * Math.PI * 0.5);
+            double max = Math.max(x, Math.max(y, z));
+            double angleRad = max * Math.PI * 0.5;
             SplatSetters.setRotationAxisAngleRad(s, x, y, z, angleRad);
         });
 
@@ -236,43 +236,43 @@ public class SplatGrids
         };
         SplatGridBuilder g = new SplatGridBuilder(7, 3, 1, supplier);
 
-        float maxPosition = 250.0f;
-        g.registerX(0.0f, maxPosition, MutableSplat::setPositionX);
-        g.registerY(0.0f, maxPosition, MutableSplat::setPositionY);
-        g.registerZ(0.0f, maxPosition, MutableSplat::setPositionZ);
+        double maxPosition = 250.0;
+        g.registerX(0.0, maxPosition, MutableSplat::setPositionX);
+        g.registerY(0.0, maxPosition, MutableSplat::setPositionY);
+        g.registerZ(0.0, maxPosition, MutableSplat::setPositionZ);
 
         g.registerY((s, y) ->
         {
-            if (y == 0.0f)
+            if (y == 0.0)
             {
-                SplatSetters.setScale(s, 3.0f, 1.0f, 1.0f);
-                SplatSetters.setColor(s, 1.0f, 0.0f, 0.0f);
+                SplatSetters.setScale(s, 3.0, 1.0, 1.0);
+                SplatSetters.setColor(s, 1.0, 0.0, 0.0);
             }
-            if (y == 0.5f)
+            if (y == 0.5)
             {
-                SplatSetters.setScale(s, 1.0f, 3.0f, 1.0f);
-                SplatSetters.setColor(s, 0.0f, 1.0f, 0.0f);
+                SplatSetters.setScale(s, 1.0, 3.0, 1.0);
+                SplatSetters.setColor(s, 0.0, 1.0, 0.0);
             }
-            if (y == 1.0f)
+            if (y == 1.0)
             {
-                SplatSetters.setScale(s, 1.0f, 1.0f, 3.0f);
-                SplatSetters.setColor(s, 0.0f, 0.0f, 1.0f);
+                SplatSetters.setScale(s, 1.0, 1.0, 3.0);
+                SplatSetters.setColor(s, 0.0, 0.0, 1.0);
             }
         });
         g.register((s, x, y, z) ->
         {
-            float aRad = (float) (x * Math.PI * 0.5);
-            if (y == 0.0f)
+            double aRad = x * Math.PI * 0.5;
+            if (y == 0.0)
             {
-                SplatSetters.setRotationAxisAngleRad(s, 0.0f, 1.0f, 0.0f, aRad);
+                SplatSetters.setRotationAxisAngleRad(s, 0.0, 1.0, 0.0, aRad);
             }
-            if (y == 0.5f)
+            if (y == 0.5)
             {
-                SplatSetters.setRotationAxisAngleRad(s, 0.0f, 0.0f, 1.0f, aRad);
+                SplatSetters.setRotationAxisAngleRad(s, 0.0, 0.0, 1.0, aRad);
             }
-            if (y == 1.0f)
+            if (y == 1.0)
             {
-                SplatSetters.setRotationAxisAngleRad(s, 1.0f, 0.0f, 0.0f, aRad);
+                SplatSetters.setRotationAxisAngleRad(s, 1.0, 0.0, 0.0, aRad);
             }
         });
 

--- a/jsplat-examples/src/main/java/de/javagl/jsplat/examples/SplatSetters.java
+++ b/jsplat-examples/src/main/java/de/javagl/jsplat/examples/SplatSetters.java
@@ -19,7 +19,7 @@ public class SplatSetters
     /**
      * Epsilon for quaternion computations
      */
-    private static final float EPSILON = 1e-6f;
+    private static final double EPSILON = 1e-6f;
     
     /**
      * Set some default values for the given splat
@@ -42,7 +42,7 @@ public class SplatSetters
      * @param y The y-component
      * @param z The z-component
      */
-    public static void setPosition(MutableSplat s, float x, float y, float z)
+    public static void setPosition(MutableSplat s, double x, double y, double z)
     {
         s.setPositionX(x);
         s.setPositionY(y);
@@ -58,7 +58,7 @@ public class SplatSetters
      * @param g The green component
      * @param b The blue component
      */
-    public static void setColor(MutableSplat s, float r, float g, float b)
+    public static void setColor(MutableSplat s, double r, double g, double b)
     {
         s.setShX(0, Splats.colorToDirectCurrent(r));
         s.setShY(0, Splats.colorToDirectCurrent(g));
@@ -76,9 +76,9 @@ public class SplatSetters
      * @param angleRad The angle, in radians
      */
     public static void setRotationAxisAngleRad(
-        MutableSplat s, float x, float y, float z, float angleRad)
+        MutableSplat s, double x, double y, double z, double angleRad)
     {
-        float q[] = createScalarLastQuaternionFromAxisAngleRad(x, y, z, angleRad);
+        double q[] = createScalarLastQuaternionFromAxisAngleRad(x, y, z, angleRad);
         s.setRotationX(q[0]);
         s.setRotationY(q[1]);
         s.setRotationZ(q[2]);
@@ -93,7 +93,7 @@ public class SplatSetters
      * @param y The scale in y-direction
      * @param z The scale in z-direction
      */
-    public static void setScale(MutableSplat s, float x, float y, float z)
+    public static void setScale(MutableSplat s, double x, double y, double z)
     {
         s.setScaleX(x);
         s.setScaleY(y);
@@ -109,11 +109,11 @@ public class SplatSetters
      * @param y The linear scale in y-direction
      * @param z The linear scale in z-direction
      */
-    public static void setScaleLinear(MutableSplat s, float x, float y, float z)
+    public static void setScaleLinear(MutableSplat s, double x, double y, double z)
     {
-        s.setScaleX((float)Math.log(x));
-        s.setScaleY((float)Math.log(y));
-        s.setScaleZ((float)Math.log(z));
+        s.setScaleX(Math.log(x));
+        s.setScaleY(Math.log(y));
+        s.setScaleZ(Math.log(z));
     }
     
     /**
@@ -126,26 +126,26 @@ public class SplatSetters
      * @param angleRad The angle, in radians
      * @return The quaternion, in scalar-last representation
      */
-    private static float[] createScalarLastQuaternionFromAxisAngleRad(float x,
-        float y, float z, float angleRad)
+    private static double[] createScalarLastQuaternionFromAxisAngleRad(double x,
+        double y, double z, double angleRad)
     {
-        float halfAngleRad = angleRad * 0.5f;
-        float s = (float) Math.sin(halfAngleRad);
+        double halfAngleRad = angleRad * 0.5f;
+        double s = Math.sin(halfAngleRad);
 
-        float lenSquared = x * x + y * y + z * z;
+        double lenSquared = x * x + y * y + z * z;
         if (lenSquared < EPSILON)
         {
-            return new float[]
-            { 0.0f, 0.0f, 0.0f, 1.0f };
+            return new double[]
+            { 0.0, 0.0, 0.0, 1.0 };
         }
 
-        float invLen = (float) (1.0 / Math.sqrt(lenSquared));
-        float qx = x * invLen * s;
-        float qy = y * invLen * s;
-        float qz = z * invLen * s;
-        float qw = (float) Math.cos(halfAngleRad);
+        double invLen = 1.0 / Math.sqrt(lenSquared);
+        double qx = x * invLen * s;
+        double qy = y * invLen * s;
+        double qz = z * invLen * s;
+        double qw = Math.cos(halfAngleRad);
 
-        float q[] = new float[]
+        double q[] = new double[]
         { qx, qy, qz, qw };
         return q;
     }
@@ -160,16 +160,16 @@ public class SplatSetters
      * @param qw The w-element (scalar)
      * @return The array
      */
-    static float[] createAxisAngleRadFromScalarLastQuaternion(float qx,
-        float qy, float qz, float qw)
+    static double[] createAxisAngleRadFromScalarLastQuaternion(double qx,
+        double qy, double qz, double qw)
     {
-        float x = 1.0f;
-        float y = 0.0f;
-        float z = 0.0f;
-        float angleRad = 0.0f;
+        double x = 1.0;
+        double y = 0.0;
+        double z = 0.0;
+        double angleRad = 0.0;
         if (Math.abs(qw - 1.0) >= EPSILON && Math.abs(qw + 1.0) >= EPSILON)
         {
-            float f = (float) (1.0 / Math.sqrt(1.0 - qw * qw));
+            double f = 1.0 / Math.sqrt(1.0 - qw * qw);
             x = qx * f;
             y = qy * f;
             z = qz * f;
@@ -177,9 +177,9 @@ public class SplatSetters
         }
         if (Math.abs(qw - 1.0) >= EPSILON)
         {
-            angleRad = (float) (2.0 * Math.acos(qw));
+            angleRad = 2.0 * Math.acos(qw);
         }
-        float a[] =
+        double a[] =
         { x, y, z, angleRad };
         return a;
     }

--- a/jsplat-examples/src/main/java/de/javagl/jsplat/examples/UnitCubeSplats.java
+++ b/jsplat-examples/src/main/java/de/javagl/jsplat/examples/UnitCubeSplats.java
@@ -19,22 +19,22 @@ public class UnitCubeSplats
     /**
      * The size of the cube
      */
-    private static final float size = 10.0f;
+    private static final double size = 10.0;
 
     /**
      * A scale factor so that the edges look nice
      */
-    private static final float edgeScale = 1.0f;
+    private static final double edgeScale = 1.0;
 
     /**
      * The base scale factor for all splats
      */
-    private static final float baseScale = 0.1f;
+    private static final double baseScale = 0.1;
 
     /**
      * The alpha value for all splats
      */
-    private static final float alpha = 1.0f;
+    private static final double alpha = 1.0;
     
     /**
      * Create a list of splats, representing a "unit cube".
@@ -49,27 +49,27 @@ public class UnitCubeSplats
 
         for (int c = 0; c < 8; c++)
         {
-            float x = (c & 1) == 0 ? 0.0f : 1.0f;
-            float y = (c & 2) == 0 ? 0.0f : 1.0f;
-            float z = (c & 4) == 0 ? 0.0f : 1.0f;
+            double x = (c & 1) == 0 ? 0.0 : 1.0;
+            double y = (c & 2) == 0 ? 0.0 : 1.0;
+            double z = (c & 4) == 0 ? 0.0 : 1.0;
 
-            add(splats, x, y, z, 1.0f, 1.0f, 1.0f);
+            add(splats, x, y, z, 1.0, 1.0, 1.0);
         }
 
-        add(splats, 0.5f, 0.0f, 0.0f, size, 1.0f, 1.0f);
-        add(splats, 0.5f, 1.0f, 0.0f, size, 1.0f, 1.0f);
-        add(splats, 0.5f, 0.0f, 1.0f, size, 1.0f, 1.0f);
-        add(splats, 0.5f, 1.0f, 1.0f, size, 1.0f, 1.0f);
+        add(splats, 0.5, 0.0, 0.0, size, 1.0, 1.0);
+        add(splats, 0.5, 1.0, 0.0, size, 1.0, 1.0);
+        add(splats, 0.5, 0.0, 1.0, size, 1.0, 1.0);
+        add(splats, 0.5, 1.0, 1.0, size, 1.0, 1.0);
 
-        add(splats, 0.0f, 0.5f, 0.0f, 1.0f, size, 1.0f);
-        add(splats, 0.0f, 0.5f, 1.0f, 1.0f, size, 1.0f);
-        add(splats, 1.0f, 0.5f, 0.0f, 1.0f, size, 1.0f);
-        add(splats, 1.0f, 0.5f, 1.0f, 1.0f, size, 1.0f);
+        add(splats, 0.0, 0.5, 0.0, 1.0, size, 1.0);
+        add(splats, 0.0, 0.5, 1.0, 1.0, size, 1.0);
+        add(splats, 1.0, 0.5, 0.0, 1.0, size, 1.0);
+        add(splats, 1.0, 0.5, 1.0, 1.0, size, 1.0);
 
-        add(splats, 0.0f, 0.0f, 0.5f, 1.0f, 1.0f, size);
-        add(splats, 0.0f, 1.0f, 0.5f, 1.0f, 1.0f, size);
-        add(splats, 1.0f, 0.0f, 0.5f, 1.0f, 1.0f, size);
-        add(splats, 1.0f, 1.0f, 0.5f, 1.0f, 1.0f, size);
+        add(splats, 0.0, 0.0, 0.5, 1.0, 1.0, size);
+        add(splats, 0.0, 1.0, 0.5, 1.0, 1.0, size);
+        add(splats, 1.0, 0.0, 0.5, 1.0, 1.0, size);
+        add(splats, 1.0, 1.0, 0.5, 1.0, 1.0, size);
 
         return splats;
     }
@@ -86,8 +86,8 @@ public class UnitCubeSplats
      * @param sy The scaling factor in y-direction
      * @param sz The scaling factor in z-direction
      */
-    private static void add(List<MutableSplat> splats, float npx, float npy,
-        float npz, float sx, float sy, float sz)
+    private static void add(List<MutableSplat> splats, double npx, double npy,
+        double npz, double sx, double sy, double sz)
     {
         MutableSplat splat = Splats.create(0);
         
@@ -99,10 +99,10 @@ public class UnitCubeSplats
         splat.setScaleY(sy * baseScale * edgeScale);
         splat.setScaleZ(sz * baseScale * edgeScale);
 
-        splat.setRotationX(0.0f);
-        splat.setRotationY(0.0f);
-        splat.setRotationZ(0.0f);
-        splat.setRotationW(1.0f);
+        splat.setRotationX(0.0);
+        splat.setRotationY(0.0);
+        splat.setRotationZ(0.0);
+        splat.setRotationW(1.0);
 
         splat.setOpacity(Splats.alphaToOpacity(alpha));
 

--- a/jsplat-examples/src/main/java/de/javagl/jsplat/examples/UnitShSplats.java
+++ b/jsplat-examples/src/main/java/de/javagl/jsplat/examples/UnitShSplats.java
@@ -19,12 +19,12 @@ public class UnitShSplats
     /**
      * The size of the cube
      */
-    private static final float size = 100.0f;
+    private static final double size = 100.0;
 
     /**
      * The base scale factor for all splats
      */
-    private static final float baseScale = 1.0f;
+    private static final double baseScale = 1.0;
 
     /**
      * Create a list of splats, representing a cube.
@@ -39,9 +39,9 @@ public class UnitShSplats
         List<MutableSplat> splats = new ArrayList<MutableSplat>();
         for (int c = 0; c < 8; c++)
         {
-            float x = -0.5f + ((c & 1) == 0 ? 0.0f : 1.0f);
-            float y = -0.5f + ((c & 2) == 0 ? 0.0f : 1.0f);
-            float z = -0.5f + ((c & 4) == 0 ? 0.0f : 1.0f);
+            double x = -0.5 + ((c & 1) == 0 ? 0.0f : 1.0f);
+            double y = -0.5 + ((c & 2) == 0 ? 0.0f : 1.0f);
+            double z = -0.5 + ((c & 4) == 0 ? 0.0f : 1.0f);
             add(splats, degree, x, y, z);
         }
         return splats;
@@ -72,77 +72,77 @@ public class UnitShSplats
     {
         MutableSplat splat = Splats.create(2);
 
-        splat.setPositionX(0.0f);
-        splat.setPositionY(0.0f);
-        splat.setPositionZ(0.0f);
+        splat.setPositionX(0.0);
+        splat.setPositionY(0.0);
+        splat.setPositionZ(0.0);
 
-        splat.setScaleX(3.0f * baseScale);
-        splat.setScaleY(3.0f * baseScale);
-        splat.setScaleZ(3.0f * baseScale);
+        splat.setScaleX(3.0 * baseScale);
+        splat.setScaleY(3.0 * baseScale);
+        splat.setScaleZ(3.0 * baseScale);
 
-        splat.setRotationX(0.0f);
-        splat.setRotationY(0.0f);
-        splat.setRotationZ(0.0f);
-        splat.setRotationW(1.0f);
+        splat.setRotationX(0.0);
+        splat.setRotationY(0.0);
+        splat.setRotationZ(0.0);
+        splat.setRotationW(1.0);
 
-        splat.setOpacity(Splats.alphaToOpacity(1.0f));
+        splat.setOpacity(Splats.alphaToOpacity(1.0));
 
         // One day, someone will read this, and wonder where
         // these values are coming from.
         
         int d = 0;
 
-        splat.setShX(d, 0.1476983315919267f);
-        splat.setShY(d, 0.14769703694704606f);
-        splat.setShZ(d, 0.14771121930450226f);
+        splat.setShX(d, 0.1476983315919267);
+        splat.setShY(d, 0.14769703694704606);
+        splat.setShZ(d, 0.14771121930450226);
         d++;
 
         // Dim 1
-        splat.setShX(d, -0.7830568718641374f);
-        splat.setShY(d, 1.054372367029317f);
-        splat.setShZ(d, -0.7830538122533596f);
+        splat.setShX(d, -0.7830568718641374);
+        splat.setShY(d, 1.054372367029317);
+        splat.setShZ(d, -0.7830538122533596);
         d++;
 
         // Dim 2
-        splat.setShX(d, 0.7830484620033045f);
-        splat.setShY(d, 0.7830548598697407f);
-        splat.setShZ(d, -1.054407314935455f);
+        splat.setShX(d, 0.7830484620033045);
+        splat.setShY(d, 0.7830548598697407);
+        splat.setShZ(d, -1.054407314935455);
         d++;
 
         // Dim 3
-        splat.setShX(d, 1.05434329450671f);
-        splat.setShY(d, -0.7829838731344525f);
-        splat.setShZ(d, -0.7830519155090939f);
+        splat.setShX(d, 1.05434329450671);
+        splat.setShY(d, -0.7829838731344525);
+        splat.setShZ(d, -0.7830519155090939);
         d++;
 
         // Dim 4
-        splat.setShX(d, 0.22883454327537334f);
-        splat.setShY(d, 0.22881694536762498f);
-        splat.setShZ(d, -7.2464152314211105E-6f);
+        splat.setShX(d, 0.22883454327537334);
+        splat.setShY(d, 0.22881694536762498);
+        splat.setShZ(d, -7.2464152314211105E-6);
         d++;
 
         // Dim 5
-        splat.setShX(d, -1.1875671158900758E-5f);
-        splat.setShY(d, -0.22880031503889064f);
-        splat.setShZ(d, -0.22880974771043117f);
+        splat.setShX(d, -1.1875671158900758E-5);
+        splat.setShY(d, -0.22880031503889064);
+        splat.setShZ(d, -0.22880974771043117);
         d++;
 
         // Dim 6
-        splat.setShX(d, -0.026421538828617974f);
-        splat.setShY(d, -0.02640910542972641f);
-        splat.setShZ(d, 0.05283968482224943f);
+        splat.setShX(d, -0.026421538828617974);
+        splat.setShY(d, -0.02640910542972641);
+        splat.setShZ(d, 0.05283968482224943);
         d++;
 
         // Dim 7
-        splat.setShX(d, -0.2289855776512113f);
-        splat.setShY(d, -1.917440275245319E-5f);
-        splat.setShZ(d, -0.2288323230516771f);
+        splat.setShX(d, -0.2289855776512113);
+        splat.setShY(d, -1.917440275245319E-5);
+        splat.setShZ(d, -0.2288323230516771);
         d++;
 
         // Dim 8
-        splat.setShX(d, 0.04575373638021474f);
-        splat.setShY(d, -0.045751875002436826f);
-        splat.setShZ(d, -8.16414088511408E-6f);
+        splat.setShX(d, 0.04575373638021474);
+        splat.setShY(d, -0.045751875002436826);
+        splat.setShZ(d, -8.16414088511408E-6);
 
         return splat;
     }
@@ -172,119 +172,119 @@ public class UnitShSplats
     {
         MutableSplat splat = Splats.create(3);
 
-        splat.setPositionX(0.0f);
-        splat.setPositionY(0.0f);
-        splat.setPositionZ(0.0f);
+        splat.setPositionX(0.0);
+        splat.setPositionY(0.0);
+        splat.setPositionZ(0.0);
 
-        splat.setScaleX(3.0f * baseScale);
-        splat.setScaleY(3.0f * baseScale);
-        splat.setScaleZ(3.0f * baseScale);
+        splat.setScaleX(3.0 * baseScale);
+        splat.setScaleY(3.0 * baseScale);
+        splat.setScaleZ(3.0 * baseScale);
 
-        splat.setRotationX(0.0f);
-        splat.setRotationY(0.0f);
-        splat.setRotationZ(0.0f);
-        splat.setRotationW(1.0f);
+        splat.setRotationX(0.0);
+        splat.setRotationY(0.0);
+        splat.setRotationZ(0.0);
+        splat.setRotationW(1.0);
 
-        splat.setOpacity(Splats.alphaToOpacity(1.0f));
+        splat.setOpacity(Splats.alphaToOpacity(1.0));
 
         // One day, someone will read this, and wonder where
         // these values are coming from.
 
         int d = 0;
 
-        splat.setShX(d, 0.19689117349855656f);
-        splat.setShY(d, 0.19701742462465832f);
-        splat.setShZ(d, 0.1968082144814114f);
+        splat.setShX(d, 0.19689117349855656);
+        splat.setShY(d, 0.19701742462465832);
+        splat.setShZ(d, 0.1968082144814114);
         d++;
 
         // Dim 1
-        splat.setShX(d, -0.6390529124621291f);
-        splat.setShY(d, 1.0730615144907147f);
-        splat.setShZ(d, -0.6388168750684198f);
+        splat.setShX(d, -0.6390529124621291);
+        splat.setShY(d, 1.0730615144907147);
+        splat.setShZ(d, -0.6388168750684198);
         d++;
 
         // Dim 2
-        splat.setShX(d, 0.6387493239628561f);
-        splat.setShY(d, 0.6386066087881057f);
-        splat.setShZ(d, -1.0728855189454842f);
+        splat.setShX(d, 0.6387493239628561);
+        splat.setShY(d, 0.6386066087881057);
+        splat.setShZ(d, -1.0728855189454842);
         d++;
 
         // Dim 3
-        splat.setShX(d, 1.0728635469386794f);
-        splat.setShY(d, -0.6389343617744989f);
-        splat.setShZ(d, -0.6387102939070701f);
+        splat.setShX(d, 1.0728635469386794);
+        splat.setShY(d, -0.6389343617744989);
+        splat.setShZ(d, -0.6387102939070701);
         d++;
 
         // Dim 4
-        splat.setShX(d, 0.2288865409514229f);
-        splat.setShY(d, 0.22883301398721945f);
-        splat.setShZ(d, -5.788200187595294E-6f);
+        splat.setShX(d, 0.2288865409514229);
+        splat.setShY(d, 0.22883301398721945);
+        splat.setShZ(d, -5.788200187595294E-6);
         d++;
 
         // Dim 5
-        splat.setShX(d, -2.5718827998844063E-5f);
-        splat.setShY(d, -0.22887600094296534f);
-        splat.setShZ(d, -0.22883277467319174f);
+        splat.setShX(d, -2.5718827998844063E-5);
+        splat.setShY(d, -0.22887600094296534);
+        splat.setShZ(d, -0.22883277467319174);
         d++;
 
         // Dim 6
-        splat.setShX(d, -0.04403047602516996f);
-        splat.setShY(d, -0.04397372941428612f);
-        splat.setShZ(d, 0.08799531361390533f);
+        splat.setShX(d, -0.04403047602516996);
+        splat.setShY(d, -0.04397372941428612);
+        splat.setShZ(d, 0.08799531361390533);
         d++;
 
         // Dim 7
-        splat.setShX(d, -0.22888164895998098f);
-        splat.setShY(d, -5.907535404192643E-6f);
-        splat.setShZ(d, -0.22906249045635607f);
+        splat.setShX(d, -0.22888164895998098);
+        splat.setShY(d, -5.907535404192643E-6);
+        splat.setShZ(d, -0.22906249045635607);
         d++;
 
         // Dim 8
-        splat.setShX(d, 0.07618985703501813f);
-        splat.setShY(d, -0.07637156357642105f);
-        splat.setShZ(d, -2.1415442069683266E-5f);
+        splat.setShX(d, 0.07618985703501813);
+        splat.setShY(d, -0.07637156357642105);
+        splat.setShZ(d, -2.1415442069683266E-5);
         d++;
 
         // Dim 9
-        splat.setShX(d, 0.2739307455019897f);
-        splat.setShY(d, 0.02589419616012356f);
-        splat.setShZ(d, 0.12407953674212568f);
+        splat.setShX(d, 0.2739307455019897);
+        splat.setShY(d, 0.02589419616012356);
+        splat.setShZ(d, 0.12407953674212568);
         d++;
 
         // Dim 10
-        splat.setShX(d, -1.285382433181138f);
-        splat.setShY(d, -1.3224151408611615f);
-        splat.setShZ(d, -1.3605540604623292f);
+        splat.setShX(d, -1.285382433181138);
+        splat.setShY(d, -1.3224151408611615);
+        splat.setShZ(d, -1.3605540604623292);
         d++;
 
         // Dim 11
-        splat.setShX(d, 0.05738138052643116f);
-        splat.setShY(d, 0.019969600263549214f);
-        splat.setShZ(d, 0.25077591195710025f);
+        splat.setShX(d, 0.05738138052643116);
+        splat.setShY(d, 0.019969600263549214);
+        splat.setShZ(d, 0.25077591195710025);
         d++;
 
         // Dim 12
-        splat.setShX(d, 0.2520360451989494f);
-        splat.setShY(d, 0.2517234445249994f);
-        splat.setShZ(d, 0.03241969076161055f);
+        splat.setShX(d, 0.2520360451989494);
+        splat.setShY(d, 0.2517234445249994);
+        splat.setShZ(d, 0.03241969076161055);
         d++;
 
         // Dim 13
-        splat.setShX(d, 0.019920206825017717f);
-        splat.setShY(d, 0.057338277160965845f);
-        splat.setShZ(d, 0.25081388794113546f);
+        splat.setShX(d, 0.019920206825017717);
+        splat.setShY(d, 0.057338277160965845);
+        splat.setShZ(d, 0.25081388794113546);
         d++;
 
         // Dim 14
-        splat.setShX(d, -0.12233861767199117f);
-        splat.setShY(d, 0.12225649047975251f);
-        splat.setShZ(d, 8.455848014232714E-6f);
+        splat.setShX(d, -0.12233861767199117);
+        splat.setShY(d, 0.12225649047975251);
+        splat.setShZ(d, 8.455848014232714E-6);
         d++;
 
         // Dim 15
-        splat.setShX(d, -0.02563393584434004f);
-        splat.setShY(d, -0.2737727007701105f);
-        splat.setShZ(d, -0.12410133512136956f);
+        splat.setShX(d, -0.02563393584434004);
+        splat.setShY(d, -0.2737727007701105);
+        splat.setShZ(d, -0.12410133512136956);
 
         return splat;
     }
@@ -299,8 +299,8 @@ public class UnitShSplats
      * @param npy The normalized y-coordinate
      * @param npz The normalized z-coordinate
      */
-    private static void add(List<MutableSplat> splats, int degree, float npx,
-        float npy, float npz)
+    private static void add(List<MutableSplat> splats, int degree, double npx,
+        double npy, double npz)
     {
         MutableSplat splat = Splats.create(degree);
 
@@ -312,24 +312,24 @@ public class UnitShSplats
         splat.setScaleY(baseScale);
         splat.setScaleZ(baseScale);
 
-        splat.setRotationX(0.0f);
-        splat.setRotationY(0.0f);
-        splat.setRotationZ(0.0f);
-        splat.setRotationW(1.0f);
+        splat.setRotationX(0.0);
+        splat.setRotationY(0.0);
+        splat.setRotationZ(0.0);
+        splat.setRotationW(1.0);
 
-        splat.setOpacity(Splats.alphaToOpacity(1.0f));
+        splat.setOpacity(Splats.alphaToOpacity(1.0));
 
-        if (npx == -0.5f && npy == -0.5f && npz == -0.5f)
+        if (npx == -0.5 && npy == -0.5 && npz == -0.5)
         {
-            splat.setShX(0, Splats.colorToDirectCurrent(0.1f));
-            splat.setShY(0, Splats.colorToDirectCurrent(0.1f));
-            splat.setShZ(0, Splats.colorToDirectCurrent(0.1f));
+            splat.setShX(0, Splats.colorToDirectCurrent(0.1));
+            splat.setShY(0, Splats.colorToDirectCurrent(0.1));
+            splat.setShZ(0, Splats.colorToDirectCurrent(0.1));
         }
         else
         {
-            splat.setShX(0, Splats.colorToDirectCurrent(npx + 0.5f));
-            splat.setShY(0, Splats.colorToDirectCurrent(npy + 0.5f));
-            splat.setShZ(0, Splats.colorToDirectCurrent(npz + 0.5f));
+            splat.setShX(0, Splats.colorToDirectCurrent(npx + 0.5));
+            splat.setShY(0, Splats.colorToDirectCurrent(npy + 0.5));
+            splat.setShZ(0, Splats.colorToDirectCurrent(npz + 0.5));
         }
 
         splats.add(splat);

--- a/jsplat-io-gltf-spz/src/main/java/de/javagl/jsplat/io/gltf/spz/GltfSpzSplatReader.java
+++ b/jsplat-io-gltf-spz/src/main/java/de/javagl/jsplat/io/gltf/spz/GltfSpzSplatReader.java
@@ -100,8 +100,13 @@ public final class GltfSpzSplatReader implements SplatListReader
             List<NodeModel> nodeModels = sceneModel.getNodeModels();
             for (NodeModel nodeModel : nodeModels)
             {
-                float[] globalTransform =
+                float[] globalTransformF =
                     nodeModel.computeGlobalTransform(null);
+                double globalTransform[] = new double[16];
+                for (int i=0; i<16; i++)
+                {
+                    globalTransform[i] = globalTransformF[i];
+                }
                 List<MeshModel> meshModels = nodeModel.getMeshModels();
                 for (MeshModel meshModel : meshModels)
                 {

--- a/jsplat-io-gltf/src/main/java/de/javagl/jsplat/io/gltf/GltfSplatReader.java
+++ b/jsplat-io-gltf/src/main/java/de/javagl/jsplat/io/gltf/GltfSplatReader.java
@@ -134,8 +134,13 @@ public final class GltfSplatReader implements SplatListReader
             List<NodeModel> nodeModels = sceneModel.getNodeModels();
             for (NodeModel nodeModel : nodeModels)
             {
-                float[] globalTransform =
+                float[] globalTransformF =
                     nodeModel.computeGlobalTransform(null);
+                double globalTransform[] = new double[16];
+                for (int i=0; i<16; i++)
+                {
+                    globalTransform[i] = globalTransformF[i];
+                }
                 List<MeshModel> meshModels = nodeModel.getMeshModels();
                 for (MeshModel meshModel : meshModels)
                 {

--- a/jsplat-io-gsplat/src/main/java/de/javagl/jsplat/io/gsplat/GsplatSplatWriter.java
+++ b/jsplat-io-gsplat/src/main/java/de/javagl/jsplat/io/gsplat/GsplatSplatWriter.java
@@ -99,23 +99,23 @@ public final class GsplatSplatWriter
     {
         // Convert from right-up-front to right-down-front by 
         // negating the y- and z-component
-        buffer.putFloat(0, splat.getPositionX());
-        buffer.putFloat(4, -splat.getPositionY());
-        buffer.putFloat(8, -splat.getPositionZ());
+        buffer.putFloat(0, (float)splat.getPositionX());
+        buffer.putFloat(4, (float)-splat.getPositionY());
+        buffer.putFloat(8, (float)-splat.getPositionZ());
         
         buffer.putFloat(12, (float) Math.exp(splat.getScaleX()));
         buffer.putFloat(16, (float) Math.exp(splat.getScaleY()));
         buffer.putFloat(20, (float) Math.exp(splat.getScaleZ()));
 
-        float sr = splat.getShX(0);
-        float sg = splat.getShY(0);
-        float sb = splat.getShZ(0);
-        float sa = splat.getOpacity();
+        double sr = splat.getShX(0);
+        double sg = splat.getShY(0);
+        double sb = splat.getShZ(0);
+        double sa = splat.getOpacity();
 
-        float fr = Splats.directCurrentToColor(sr);
-        float fg = Splats.directCurrentToColor(sg);
-        float fb = Splats.directCurrentToColor(sb);
-        float fa = Splats.opacityToAlpha(sa);
+        double fr = Splats.directCurrentToColor(sr);
+        double fg = Splats.directCurrentToColor(sg);
+        double fb = Splats.directCurrentToColor(sb);
+        double fa = Splats.opacityToAlpha(sa);
 
         byte r = (byte) (fr * 255.0);
         byte g = (byte) (fg * 255.0);
@@ -129,13 +129,13 @@ public final class GsplatSplatWriter
 
         // Convert from right-up-front to right-down-front by 
         // negating the y- and z-component
-        float srx = splat.getRotationX();
-        float sry = -splat.getRotationY();
-        float srz = -splat.getRotationZ();
-        float srw = splat.getRotationW();
+        double srx = splat.getRotationX();
+        double sry = -splat.getRotationY();
+        double srz = -splat.getRotationZ();
+        double srw = splat.getRotationW();
         
-        float lenSquared = srx * srx + sry * sry + srz * srz + srw * srw;
-        float invLen = (float) (1.0 / Math.sqrt(lenSquared));
+        double lenSquared = srx * srx + sry * sry + srz * srz + srw * srw;
+        double invLen = 1.0 / Math.sqrt(lenSquared);
         
         byte rx = (byte) ((srx * invLen) * 128.0 + 128.0);
         byte ry = (byte) ((sry * invLen) * 128.0 + 128.0);

--- a/jsplat-io-ply/src/main/java/de/javagl/jsplat/io/ply/PlySplatReader.java
+++ b/jsplat-io-ply/src/main/java/de/javagl/jsplat/io/ply/PlySplatReader.java
@@ -114,7 +114,7 @@ public final class PlySplatReader implements SplatListReader
 
         // PLY uses scalar-first quaternions
         h.withFloat("rot_0", (s, v) -> s.setRotationW(v));
-        h.withFloat("rot_1", (s, v) -> s.setRotationY(v));
+        h.withFloat("rot_1", (s, v) -> s.setRotationX(v));
         h.withFloat("rot_2", (s, v) -> s.setRotationY(v));
         h.withFloat("rot_3", (s, v) -> s.setRotationZ(v));
 

--- a/jsplat-io-ply/src/main/java/de/javagl/jsplat/io/ply/PlySplatReader.java
+++ b/jsplat-io-ply/src/main/java/de/javagl/jsplat/io/ply/PlySplatReader.java
@@ -78,16 +78,16 @@ public final class PlySplatReader implements SplatListReader
         // a quick solution for the time being.
         if (isDouble(descriptor, "x"))
         {
-            h.withDouble("x", (s, x) -> s.setPositionX(x.floatValue()));
+            h.withDouble("x", (s, x) -> s.setPositionX(x));
         }
         else
         {
-            h.withFloat("x", MutableSplat::setPositionX);
+            h.withFloat("x", (s, x) -> s.setPositionX(x));
         }
 
         if (isDouble(descriptor, "y"))
         {
-            h.withDouble("y", (s, y) -> s.setPositionY(y.floatValue()));
+            h.withDouble("y", (s, y) -> s.setPositionY(y));
         }
         else
         {
@@ -95,7 +95,7 @@ public final class PlySplatReader implements SplatListReader
         }
         if (isDouble(descriptor, "z"))
         {
-            h.withDouble("z", (s, z) -> s.setPositionZ(z.floatValue()));
+            h.withDouble("z", (s, z) -> s.setPositionZ(z));
         }
         else
         {
@@ -106,16 +106,17 @@ public final class PlySplatReader implements SplatListReader
         h.withFloat("f_dc_1", (s, v) -> s.setShY(0, v));
         h.withFloat("f_dc_2", (s, v) -> s.setShZ(0, v));
 
-        h.withFloat("opacity", MutableSplat::setOpacity);
-        h.withFloat("scale_0", MutableSplat::setScaleX);
-        h.withFloat("scale_1", MutableSplat::setScaleY);
-        h.withFloat("scale_2", MutableSplat::setScaleZ);
+        h.withFloat("opacity", (s, v) -> s.setOpacity(v));
+        
+        h.withFloat("scale_0", (s, v) -> s.setScaleX(v));
+        h.withFloat("scale_1", (s, v) -> s.setScaleY(v));
+        h.withFloat("scale_2", (s, v) -> s.setScaleZ(v));
 
         // PLY uses scalar-first quaternions
-        h.withFloat("rot_0", MutableSplat::setRotationW);
-        h.withFloat("rot_1", MutableSplat::setRotationX);
-        h.withFloat("rot_2", MutableSplat::setRotationY);
-        h.withFloat("rot_3", MutableSplat::setRotationZ);
+        h.withFloat("rot_0", (s, v) -> s.setRotationW(v));
+        h.withFloat("rot_1", (s, v) -> s.setRotationY(v));
+        h.withFloat("rot_2", (s, v) -> s.setRotationY(v));
+        h.withFloat("rot_3", (s, v) -> s.setRotationZ(v));
 
         for (int d = 0; d < shDimensions - 1; d++)
         {
@@ -134,12 +135,12 @@ public final class PlySplatReader implements SplatListReader
         // Rotate about 180 degrees around x, to convert from
         // right-down-back to right-up-front
         // @formatter:off
-        float rotate180X[] = 
+        double rotate180X[] = 
         { 
-            1.0f,  0.0f,  0.0f, 0.0f, 
-            0.0f, -1.0f,  0.0f, 0.0f, 
-            0.0f,  0.0f, -1.0f, 0.0f, 
-            0.0f,  0.0f,  0.0f, 1.0f 
+            1.0,  0.0,  0.0, 0.0, 
+            0.0, -1.0,  0.0, 0.0, 
+            0.0,  0.0, -1.0, 0.0, 
+            0.0,  0.0,  0.0, 1.0 
         };
         // @formatter:on
         SplatTransforms.transformList(splats, rotate180X);

--- a/jsplat-io-ply/src/main/java/de/javagl/jsplat/io/ply/PlySplatWriter.java
+++ b/jsplat-io-ply/src/main/java/de/javagl/jsplat/io/ply/PlySplatWriter.java
@@ -162,12 +162,12 @@ public final class PlySplatWriter implements SplatListWriter
         // Rotate about 180 degrees around x, to convert from
         // right-up-front to right-down-back
         // @formatter:off
-        float rotate180X[] = 
+        double rotate180X[] = 
         { 
-            1.0f,  0.0f,  0.0f, 0.0f, 
-            0.0f, -1.0f,  0.0f, 0.0f, 
-            0.0f,  0.0f, -1.0f, 0.0f, 
-            0.0f,  0.0f,  0.0f, 1.0f 
+            1.0,  0.0,  0.0, 0.0, 
+            0.0, -1.0,  0.0, 0.0, 
+            0.0,  0.0, -1.0, 0.0, 
+            0.0,  0.0,  0.0, 1.0 
         };
         // @formatter:on
         Consumer<MutableSplat> transform =
@@ -198,13 +198,13 @@ public final class PlySplatWriter implements SplatListWriter
         List<MutableSplat> splats = createMapped(inputSplats);
         Handle<? extends Splat> v = plySource.register("vertex", splats);
 
-        v.withFloat("x", Splat::getPositionX);
-        v.withFloat("y", Splat::getPositionY);
-        v.withFloat("z", Splat::getPositionZ);
+        v.withFloat("x", s -> (float)s.getPositionX());
+        v.withFloat("y", s -> (float)s.getPositionY());
+        v.withFloat("z", s -> (float)s.getPositionZ());
 
-        v.withFloat("f_dc_0", (s) -> s.getShX(0));
-        v.withFloat("f_dc_1", (s) -> s.getShY(0));
-        v.withFloat("f_dc_2", (s) -> s.getShZ(0));
+        v.withFloat("f_dc_0", s -> (float)s.getShX(0));
+        v.withFloat("f_dc_1", s -> (float)s.getShY(0));
+        v.withFloat("f_dc_2", s -> (float)s.getShZ(0));
 
         int shDimensions = Splats.dimensionsForDegree(shDegree);
         for (int d = 0; d < shDimensions - 1; d++)
@@ -213,22 +213,22 @@ public final class PlySplatWriter implements SplatListWriter
             int ix = (shDimensions - 1) * 0 + d;
             int iy = (shDimensions - 1) * 1 + d;
             int iz = (shDimensions - 1) * 2 + d;
-            v.withFloat("f_rest_" + ix, (s) -> s.getShX(sd));
-            v.withFloat("f_rest_" + iy, (s) -> s.getShY(sd));
-            v.withFloat("f_rest_" + iz, (s) -> s.getShZ(sd));
+            v.withFloat("f_rest_" + ix, s -> (float)s.getShX(sd));
+            v.withFloat("f_rest_" + iy, s -> (float)s.getShY(sd));
+            v.withFloat("f_rest_" + iz, s -> (float)s.getShZ(sd));
         }
 
-        v.withFloat("opacity", Splat::getOpacity);
+        v.withFloat("opacity", s -> (float)s.getOpacity());
 
-        v.withFloat("scale_0", Splat::getScaleX);
-        v.withFloat("scale_1", Splat::getScaleY);
-        v.withFloat("scale_2", Splat::getScaleZ);
+        v.withFloat("scale_0", s -> (float)s.getScaleX());
+        v.withFloat("scale_1", s -> (float)s.getScaleY());
+        v.withFloat("scale_2", s -> (float)s.getScaleZ());
 
         // PLY uses scalar-first quaternions
-        v.withFloat("rot_0", Splat::getRotationW);
-        v.withFloat("rot_1", Splat::getRotationX);
-        v.withFloat("rot_2", Splat::getRotationY);
-        v.withFloat("rot_3", Splat::getRotationZ);
+        v.withFloat("rot_0", s -> (float)s.getRotationW());
+        v.withFloat("rot_1", s -> (float)s.getRotationY());
+        v.withFloat("rot_2", s -> (float)s.getRotationY());
+        v.withFloat("rot_3", s -> (float)s.getRotationZ());
 
         if (plyFormat == PlyFormat.ASCII)
         {

--- a/jsplat-io-ply/src/main/java/de/javagl/jsplat/io/ply/PlySplatWriter.java
+++ b/jsplat-io-ply/src/main/java/de/javagl/jsplat/io/ply/PlySplatWriter.java
@@ -226,7 +226,7 @@ public final class PlySplatWriter implements SplatListWriter
 
         // PLY uses scalar-first quaternions
         v.withFloat("rot_0", s -> (float)s.getRotationW());
-        v.withFloat("rot_1", s -> (float)s.getRotationY());
+        v.withFloat("rot_1", s -> (float)s.getRotationX());
         v.withFloat("rot_2", s -> (float)s.getRotationY());
         v.withFloat("rot_3", s -> (float)s.getRotationZ());
 

--- a/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/Clustering.java
+++ b/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/Clustering.java
@@ -46,7 +46,7 @@ class Clustering
         /**
          * The centroids
          */
-        float centroids[][];
+        double centroids[][];
         
         /**
          * The labels

--- a/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/ClusteringElki.java
+++ b/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/ClusteringElki.java
@@ -184,7 +184,7 @@ class ClusteringElki
     {
         // Disable logging to not warn about empty clusters
         System.setProperty("java.util.logging.config.file",
-            "ElkiIsMessingWithLoging");
+            "ElkiIsMessingWithLogging");
         Logger logger = Logger.getLogger("elki");
         logger.setLevel(Level.OFF);
         LoggingConfiguration.setLevelFor("elki.clustering.kmeans", "SEVERE");

--- a/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/ClusteringElki.java
+++ b/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/ClusteringElki.java
@@ -111,7 +111,7 @@ class ClusteringElki
         int desiredK, DBIDRange dbIds, Clustering<KMeansModel> clustering)
     {
         int labels[] = new int[numRows];
-        float centroids[][] = new float[desiredK][];
+        double centroids[][] = new double[desiredK][];
         List<Cluster<KMeansModel>> clusters = clustering.getAllClusters();
         for (int c = 0; c < desiredK; c++)
         {
@@ -119,7 +119,7 @@ class ClusteringElki
             // larger than the number of data points
             if (c >= clusters.size())
             {
-                centroids[c] = new float[numCols];
+                centroids[c] = new double[numCols];
                 continue;
             }
 
@@ -140,13 +140,7 @@ class ClusteringElki
 
             // Extract the means as the "centroids"
             KMeansModel model = cluster.getModel();
-            double[] mean = model.getMean();
-            float centroid[] = new float[mean.length];
-            for (int i = 0; i < mean.length; i++)
-            {
-                centroid[i] = (float) mean[i];
-            }
-            centroids[c] = centroid;
+            centroids[c] = model.getMean();
         }
 
         ClusteringResult clusteringResult = new ClusteringResult();

--- a/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/IntDoubleFunction.java
+++ b/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/IntDoubleFunction.java
@@ -27,9 +27,9 @@
 package de.javagl.jsplat.io.sog;
 
 /**
- * Interface for a function that receives an int, and returns a float.
+ * Interface for a function that receives an int, and returns a double.
  */
-interface IntFloatFunction
+interface IntDoubleFunction
 {
     /**
      * Apply this function to the given value
@@ -37,5 +37,5 @@ interface IntFloatFunction
      * @param i The value
      * @return The result
      */
-    float apply(int i);
+    double apply(int i);
 }

--- a/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/SogClustering.java
+++ b/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/SogClustering.java
@@ -54,7 +54,7 @@ class SogClustering
         /**
          * The centroids
          */
-        float centroids[];
+        double centroids[];
 
         /**
          * The labels
@@ -72,7 +72,7 @@ class SogClustering
      * @param columns The columns of the input data
      * @return The clustering result
      */
-    static ClusteringResult1D cluster1d(int numRows, IntFloatFunction columns[])
+    static ClusteringResult1D cluster1d(int numRows, IntDoubleFunction columns[])
     {
         // Convert the given data into a 1D table
         int numColumns = columns.length;
@@ -87,13 +87,13 @@ class SogClustering
 
         // Compute the ND-clustering
         ClusteringResult clusteringResult = Clustering.compute(data, 256);
-        float[][] centroids = clusteringResult.centroids;
+        double[][] centroids = clusteringResult.centroids;
         int[] labels = clusteringResult.labels;
 
         // Ported from the SOG implementation:
 
         // order centroids smallest to largest
-        List<float[]> centroidsData = Arrays.asList(centroids);
+        List<double[]> centroidsData = Arrays.asList(centroids);
         List<Integer> order = new ArrayList<Integer>();
         for (int i = 0; i < centroidsData.size(); i++)
         {
@@ -101,13 +101,13 @@ class SogClustering
         }
         Collections.sort(order, (i0, i1) ->
         {
-            float[] c0 = centroidsData.get(i0);
-            float[] c1 = centroidsData.get(i1);
-            return Float.compare(c0[0], c1[0]);
+            double[] c0 = centroidsData.get(i0);
+            double[] c1 = centroidsData.get(i1);
+            return Double.compare(c0[0], c1[0]);
         });
 
         // reorder centroids
-        List<float[]> tmp = new ArrayList<float[]>(centroidsData);
+        List<double[]> tmp = new ArrayList<double[]>(centroidsData);
         for (int i = 0; i < order.size(); ++i)
         {
             centroidsData.set(i, tmp.get(order.get(i)));
@@ -138,7 +138,7 @@ class SogClustering
             }
         }
         ClusteringResult1D clusteringResult1D = new ClusteringResult1D();
-        clusteringResult1D.centroids = new float[256];
+        clusteringResult1D.centroids = new double[256];
         for (int i = 0; i < centroids.length; i++)
         {
             clusteringResult1D.centroids[i] = centroids[i][0];

--- a/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/SogDataGenerator.java
+++ b/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/SogDataGenerator.java
@@ -132,7 +132,7 @@ class SogDataGenerator
         this.indices = generateIndices();
         int numRows = splats.size();
         this.width = (int) Math.ceil(Math.sqrt(numRows) / 4) * 4;
-        this.height = (int) Math.ceil((float) numRows / width / 4) * 4;
+        this.height = (int) Math.ceil((double) numRows / width / 4) * 4;
         this.channels = 4;
 
         // Create the SogData object, and initialize the top-level metadata
@@ -214,9 +214,9 @@ class SogDataGenerator
         {
             result.put(i, i);
         }
-        IntFloatFunction cx = i -> splats.get(i).getPositionX();
-        IntFloatFunction cy = i -> splats.get(i).getPositionY();
-        IntFloatFunction cz = i -> splats.get(i).getPositionZ();
+        IntDoubleFunction cx = i -> splats.get(i).getPositionX();
+        IntDoubleFunction cy = i -> splats.get(i).getPositionY();
+        IntDoubleFunction cz = i -> splats.get(i).getPositionZ();
         SogMortonOrder.generate(result, cx, cy, cz);
         return result;
     };
@@ -246,12 +246,12 @@ class SogDataGenerator
         byte meansL[] = new byte[width * height * channels];
         byte meansU[] = new byte[width * height * channels];
 
-        IntFloatFunction cx = i -> splats.get(i).getPositionX();
-        IntFloatFunction cy = i -> splats.get(i).getPositionY();
-        IntFloatFunction cz = i -> splats.get(i).getPositionZ();
-        IntFloatFunction columns[] =
+        IntDoubleFunction cx = i -> splats.get(i).getPositionX();
+        IntDoubleFunction cy = i -> splats.get(i).getPositionY();
+        IntDoubleFunction cz = i -> splats.get(i).getPositionZ();
+        IntDoubleFunction columns[] =
         { cx, cy, cz };
-        float meansMinMax[][] = computeMinMax(indices.capacity(), columns);
+        double meansMinMax[][] = computeMinMax(indices.capacity(), columns);
         for (int i = 0; i < meansMinMax.length; i++)
         {
             for (int j = 0; j < meansMinMax[i].length; j++)
@@ -262,13 +262,13 @@ class SogDataGenerator
         for (int i = 0; i < indices.capacity(); ++i)
         {
             int index = indices.get(i);
-            float rowx = cx.apply(index);
-            float rowy = cy.apply(index);
-            float rowz = cz.apply(index);
+            double rowx = cx.apply(index);
+            double rowy = cy.apply(index);
+            double rowz = cz.apply(index);
 
-            float x = meanTransform(rowx, meansMinMax[0]);
-            float y = meanTransform(rowy, meansMinMax[1]);
-            float z = meanTransform(rowz, meansMinMax[2]);
+            double x = meanTransform(rowx, meansMinMax[0]);
+            double y = meanTransform(rowy, meansMinMax[1]);
+            double z = meanTransform(rowz, meansMinMax[2]);
 
             int ti = layout(i, width);
 
@@ -285,9 +285,9 @@ class SogDataGenerator
 
         // Assign the result to the SogData
         Means means = new Means();
-        means.mins = new float[]
+        means.mins = new double[]
         { meansMinMax[0][0], meansMinMax[1][0], meansMinMax[2][0], };
-        means.maxs = new float[]
+        means.maxs = new double[]
         { meansMinMax[0][1], meansMinMax[1][1], meansMinMax[2][1], };
         means.files = new String[]
         { "means_l.webp", "means_u.webp" };
@@ -305,10 +305,10 @@ class SogDataGenerator
      * @param minMax The minimum/maximum
      * @return The result
      */
-    private static float meanTransform(float value, float minMax[])
+    private static double meanTransform(double value, double minMax[])
     {
-        float min = minMax[0];
-        float max = minMax[1];
+        double min = minMax[0];
+        double max = minMax[1];
         return 65535.0f * (logTransform(value) - min) / (max - min);
     }
 
@@ -321,19 +321,19 @@ class SogDataGenerator
 
         byte quatsPixelData[] = new byte[width * height * channels];
 
-        IntFloatFunction cw = i -> splats.get(i).getRotationW();
-        IntFloatFunction cx = i -> splats.get(i).getRotationX();
-        IntFloatFunction cy = i -> splats.get(i).getRotationY();
-        IntFloatFunction cz = i -> splats.get(i).getRotationZ();
-        float q[] = new float[]
+        IntDoubleFunction cw = i -> splats.get(i).getRotationW();
+        IntDoubleFunction cx = i -> splats.get(i).getRotationX();
+        IntDoubleFunction cy = i -> splats.get(i).getRotationY();
+        IntDoubleFunction cz = i -> splats.get(i).getRotationZ();
+        double q[] = new double[]
         { 0, 0, 0, 0 };
         for (int i = 0; i < indices.capacity(); ++i)
         {
             int index = indices.get(i);
-            float rowrot_0 = cw.apply(index);
-            float rowrot_1 = cx.apply(index);
-            float rowrot_2 = cy.apply(index);
-            float rowrot_3 = cz.apply(index);
+            double rowrot_0 = cw.apply(index);
+            double rowrot_1 = cx.apply(index);
+            double rowrot_2 = cy.apply(index);
+            double rowrot_3 = cz.apply(index);
             q[0] = rowrot_0;
             q[1] = rowrot_1;
             q[2] = rowrot_2;
@@ -358,10 +358,10 @@ class SogDataGenerator
     {
         logger.fine("Generating SOG scales");
 
-        IntFloatFunction cx = i -> splats.get(i).getScaleX();
-        IntFloatFunction cy = i -> splats.get(i).getScaleY();
-        IntFloatFunction cz = i -> splats.get(i).getScaleZ();
-        IntFloatFunction columns[] =
+        IntDoubleFunction cx = i -> splats.get(i).getScaleX();
+        IntDoubleFunction cy = i -> splats.get(i).getScaleY();
+        IntDoubleFunction cz = i -> splats.get(i).getScaleZ();
+        IntDoubleFunction columns[] =
         { cx, cy, cz };
         ClusteringResult1D scaleData =
             SogClustering.cluster1d(splats.size(), columns);
@@ -385,10 +385,10 @@ class SogDataGenerator
     {
         logger.fine("Generating SOG colors");
 
-        IntFloatFunction cx = i -> splats.get(i).getShX(0);
-        IntFloatFunction cy = i -> splats.get(i).getShY(0);
-        IntFloatFunction cz = i -> splats.get(i).getShZ(0);
-        IntFloatFunction columns[] =
+        IntDoubleFunction cx = i -> splats.get(i).getShX(0);
+        IntDoubleFunction cy = i -> splats.get(i).getShY(0);
+        IntDoubleFunction cz = i -> splats.get(i).getShZ(0);
+        IntDoubleFunction columns[] =
         { cx, cy, cz };
 
         int numRows = splats.size();
@@ -396,11 +396,11 @@ class SogDataGenerator
             SogClustering.cluster1d(numRows, columns);
 
         // generate and store sigmoid(opacity) [0..1]
-        IntFloatFunction opacity = i -> splats.get(i).getOpacity();
+        IntDoubleFunction opacity = i -> splats.get(i).getOpacity();
         byte opacityData[] = new byte[numRows];
         for (int i = 0; i < numRows; ++i)
         {
-            float alpha = Splats.opacityToAlpha(opacity.apply(i));
+            double alpha = Splats.opacityToAlpha(opacity.apply(i));
             opacityData[i] = (byte) Math.max(0, Math.min(255, alpha * 255));
         }
 
@@ -468,11 +468,11 @@ class SogDataGenerator
         // Compute the clustering on the SH data
         ClusteringResult clusteringResult =
             Clustering.compute(shDataTable, paletteSize);
-        float[][] centroids = clusteringResult.centroids;
+        double[][] centroids = clusteringResult.centroids;
         int[] labels = clusteringResult.labels;
 
         // Create some sort of a "data table" from the SH centroids
-        IntFloatFunction columns[] = new IntFloatFunction[shCoeffs * 3];
+        IntDoubleFunction columns[] = new IntDoubleFunction[shCoeffs * 3];
         for (int i = 0; i < columns.length; i++)
         {
             int c = i;
@@ -484,7 +484,7 @@ class SogDataGenerator
         // Perform the clustering in the centroids
         ClusteringResult1D clusteringResult1D =
             SogClustering.cluster1d(centroids.length, columns);
-        float codebookCentroids[] = clusteringResult1D.centroids;
+        double codebookCentroids[] = clusteringResult1D.centroids;
         byte codebookLabels[][] = clusteringResult1D.labels;
 
         // Convert the centroids into the pixel representation
@@ -570,21 +570,21 @@ class SogDataGenerator
      * @param columns The colums
      * @return The result
      */
-    private static float[][] computeMinMax(int numRows,
-        IntFloatFunction columns[])
+    private static double[][] computeMinMax(int numRows,
+        IntDoubleFunction columns[])
     {
-        float minMax[][] = new float[columns.length][2];
+        double minMax[][] = new double[columns.length][2];
         for (int j = 0; j < columns.length; ++j)
         {
-            minMax[j][0] = Float.POSITIVE_INFINITY;
-            minMax[j][1] = Float.NEGATIVE_INFINITY;
+            minMax[j][0] = Double.POSITIVE_INFINITY;
+            minMax[j][1] = Double.NEGATIVE_INFINITY;
         }
 
         for (int i = 0; i < numRows; ++i)
         {
             for (int j = 0; j < columns.length; ++j)
             {
-                float value = columns[j].apply(i);
+                double value = columns[j].apply(i);
                 if (value < minMax[j][0])
                 {
                     minMax[j][0] = value;
@@ -609,7 +609,7 @@ class SogDataGenerator
      * @param index The index inside the quats array
      * @param width The image width
      */
-    private static void encodeQuaternion(float q[], byte quats[], int index,
+    private static void encodeQuaternion(double q[], byte quats[], int index,
         int width)
     {
         double len =
@@ -661,13 +661,13 @@ class SogDataGenerator
      * @param a The array
      * @return The result
      */
-    private static int indexOfMaxAbs(float a[])
+    private static int indexOfMaxAbs(double a[])
     {
         int index = -1;
-        float maxAbs = Float.NEGATIVE_INFINITY;
+        double maxAbs = Double.NEGATIVE_INFINITY;
         for (int i = 0; i < a.length; i++)
         {
-            float m = Math.abs(a[i]);
+            double m = Math.abs(a[i]);
             if (m > maxAbs)
             {
                 index = i;
@@ -683,9 +683,9 @@ class SogDataGenerator
      * @param value The input
      * @return The result
      */
-    private static float logTransform(float value)
+    private static double logTransform(double value)
     {
-        return (float) (Math.signum(value) * Math.log(Math.abs(value) + 1));
+        return Math.signum(value) * Math.log(Math.abs(value) + 1);
     }
 
     /**

--- a/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/SogMortonOrder.java
+++ b/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/SogMortonOrder.java
@@ -47,24 +47,24 @@ import java.util.List;
 @SuppressWarnings("javadoc")
 class SogMortonOrder
 {
-    static void generate(IntBuffer indices, IntFloatFunction cx,
-        IntFloatFunction cy, IntFloatFunction cz)
+    static void generate(IntBuffer indices, IntDoubleFunction cx,
+        IntDoubleFunction cy, IntDoubleFunction cz)
     {
-        float mx = 0.0f;
-        float my = 0.0f;
-        float mz = 0.0f;
-        float Mx = 0.0f;
-        float My = 0.0f;
-        float Mz = 0.0f;
+        double mx = 0.0;
+        double my = 0.0;
+        double mz = 0.0;
+        double Mx = 0.0;
+        double My = 0.0;
+        double Mz = 0.0;
 
         // calculate scene extents across all splats (using sort
         // centers, because they're in world space)
         for (int i = 0; i < indices.capacity(); ++i)
         {
             int ri = indices.get(i);
-            float x = cx.apply(ri);
-            float y = cy.apply(ri);
-            float z = cz.apply(ri);
+            double x = cx.apply(ri);
+            double y = cy.apply(ri);
+            double z = cz.apply(ri);
 
             if (i == 0)
             {
@@ -101,12 +101,12 @@ class SogMortonOrder
             }
         }
 
-        float xlen = Mx - mx;
-        float ylen = My - my;
-        float zlen = Mz - mz;
+        double xlen = Mx - mx;
+        double ylen = My - my;
+        double zlen = Mz - mz;
 
-        if (!Float.isFinite(xlen) || !Float.isFinite(ylen)
-            || !Float.isFinite(zlen))
+        if (!Double.isFinite(xlen) || !Double.isFinite(ylen)
+            || !Double.isFinite(zlen))
         {
             System.err
                 .println("invalid extents: " + xlen + " " + ylen + " " + zlen);
@@ -119,17 +119,17 @@ class SogMortonOrder
             return;
         }
 
-        float xmul = (xlen == 0.0f) ? 0.0f : 1024.0f / xlen;
-        float ymul = (ylen == 0.0f) ? 0.0f : 1024.0f / ylen;
-        float zmul = (zlen == 0.0f) ? 0.0f : 1024.0f / zlen;
+        double xmul = (xlen == 0.0f) ? 0.0 : 1024.0 / xlen;
+        double ymul = (ylen == 0.0f) ? 0.0 : 1024.0 / ylen;
+        double zmul = (zlen == 0.0f) ? 0.0 : 1024.0 / zlen;
 
         int morton[] = new int[indices.capacity()];
         for (int i = 0; i < indices.capacity(); ++i)
         {
             int ri = indices.get(i);
-            float x = cx.apply(ri);
-            float y = cy.apply(ri);
-            float z = cz.apply(ri);
+            double x = cx.apply(ri);
+            double y = cy.apply(ri);
+            double z = cz.apply(ri);
 
             int ix = (int) Math.min(1023, (x - mx) * xmul);
             int iy = (int) Math.min(1023, (y - my) * ymul);

--- a/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/SogSplatReader.java
+++ b/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/SogSplatReader.java
@@ -331,14 +331,14 @@ public final class SogSplatReader implements SplatListReader
         int qz = (meansUb << 8) | meansLb;
 
         // Dequantize into log-domain nx,ny,nz using per-axis ranges from meta:
-        float nx = lerp(means.mins[0], means.maxs[0], qx / 65535.0f);
-        float ny = lerp(means.mins[1], means.maxs[1], qy / 65535.0f);
-        float nz = lerp(means.mins[2], means.maxs[2], qz / 65535.0f);
+        double nx = lerp(means.mins[0], means.maxs[0], qx / 65535.0);
+        double ny = lerp(means.mins[1], means.maxs[1], qy / 65535.0);
+        double nz = lerp(means.mins[2], means.maxs[2], qz / 65535.0);
 
         // Undo the symmetric log transform used at encode time:
-        float x = unlog(nx);
-        float y = unlog(ny);
-        float z = unlog(nz);
+        double x = unlog(nx);
+        double y = unlog(ny);
+        double z = unlog(nz);
 
         s.setPositionX(x);
         s.setPositionY(y);
@@ -363,42 +363,42 @@ public final class SogSplatReader implements SplatListReader
         int quatsa = Byte.toUnsignedInt(quats[index * 4 + 3]);
 
         // Dequantize the stored three components:
-        float a = toComp(quatsr);
-        float b = toComp(quatsg);
-        float c = toComp(quatsb);
+        double a = toComp(quatsr);
+        double b = toComp(quatsg);
+        double c = toComp(quatsb);
 
         // 0..3 (R,G,B,A is one of the four components)
         int mode = (int) (quatsa - 252);
 
         // Reconstruct the omitted component so that ||q|| = 1
         // and w.l.o.g. the omitted one is non-negative
-        float t = a * a + b * b + c * c;
-        float d = (float) Math.sqrt(Math.max(0, 1 - t));
+        double t = a * a + b * b + c * c;
+        double d = Math.sqrt(Math.max(0, 1 - t));
 
         // Place components according to mode
-        float q[];
+        double q[];
         switch (mode)
         {
             case 0:
-                q = new float[]
+                q = new double[]
                 { d, a, b, c };
                 break; // omitted = x
             case 1:
-                q = new float[]
+                q = new double[]
                 { a, d, b, c };
                 break; // omitted = y
             case 2:
-                q = new float[]
+                q = new double[]
                 { a, b, d, c };
                 break; // omitted = z
             case 3:
-                q = new float[]
+                q = new double[]
                 { a, b, c, d };
                 break; // omitted = w
             default:
                 System.err.println("Invalid quaternion mode");
-                q = new float[]
-                { 1.0f, 0.0f, 0.0f, 0.0f };
+                q = new double[]
+                { 1.0, 0.0, 0.0, 0.0 };
         }
         s.setRotationW(q[0]);
         s.setRotationX(q[1]);
@@ -417,15 +417,15 @@ public final class SogSplatReader implements SplatListReader
      * @throws IOException If an IO error occurs
      */
     private static void convertScales(MutableSplat s, int index,
-        float codebook[], byte[] scales) throws IOException
+        double codebook[], byte[] scales) throws IOException
     {
         int scalesr = Byte.toUnsignedInt(scales[index * 4 + 0]);
         int scalesg = Byte.toUnsignedInt(scales[index * 4 + 1]);
         int scalesb = Byte.toUnsignedInt(scales[index * 4 + 2]);
 
-        float sx = codebook[scalesr];
-        float sy = codebook[scalesg];
-        float sz = codebook[scalesb];
+        double sx = codebook[scalesr];
+        double sy = codebook[scalesg];
+        double sz = codebook[scalesb];
 
         s.setScaleX(sx);
         s.setScaleY(sy);
@@ -441,7 +441,7 @@ public final class SogSplatReader implements SplatListReader
      * @param sh0 The sh0 image
      * @throws IOException If an IO error occurs
      */
-    private static void convertSh0(MutableSplat s, int index, float codebook[],
+    private static void convertSh0(MutableSplat s, int index, double codebook[],
         byte[] sh0) throws IOException
     {
         int sh0r = Byte.toUnsignedInt(sh0[index * 4 + 0]);
@@ -450,10 +450,10 @@ public final class SogSplatReader implements SplatListReader
         int sh0a = Byte.toUnsignedInt(sh0[index * 4 + 3]);
 
         // Not converting to "color" here
-        float r = codebook[sh0r];
-        float g = codebook[sh0g];
-        float b = codebook[sh0b];
-        float a = sh0a / 255.0f;
+        double r = codebook[sh0r];
+        double g = codebook[sh0g];
+        double b = codebook[sh0b];
+        double a = sh0a / 255.0;
 
         s.setShX(0, r);
         s.setShY(0, g);
@@ -493,9 +493,9 @@ public final class SogSplatReader implements SplatListReader
             int centroidr = Byte.toUnsignedInt(shNCentroids[base * 4 + 0]);
             int centroidg = Byte.toUnsignedInt(shNCentroids[base * 4 + 1]);
             int centroidb = Byte.toUnsignedInt(shNCentroids[base * 4 + 2]);
-            float x = shN.codebook[centroidr];
-            float y = shN.codebook[centroidg];
-            float z = shN.codebook[centroidb];
+            double x = shN.codebook[centroidr];
+            double y = shN.codebook[centroidg];
+            double z = shN.codebook[centroidb];
             s.setShX(k + 1, x);
             s.setShY(k + 1, y);
             s.setShZ(k + 1, z);
@@ -510,7 +510,7 @@ public final class SogSplatReader implements SplatListReader
      * @param t The interpolation value
      * @return The result
      */
-    private static float lerp(float a, float b, float t)
+    private static double lerp(double a, double b, double t)
     {
         return a + (b - a) * t;
     }
@@ -521,9 +521,9 @@ public final class SogSplatReader implements SplatListReader
      * @param n The input
      * @return The result
      */
-    private static float unlog(float n)
+    private static double unlog(double n)
     {
-        return (float) (Math.signum(n) * (Math.exp(Math.abs(n)) - 1));
+        return Math.signum(n) * (Math.exp(Math.abs(n)) - 1);
     }
 
     /**
@@ -532,9 +532,9 @@ public final class SogSplatReader implements SplatListReader
      * @param c The input
      * @return The result
      */
-    private static float toComp(float c)
+    private static double toComp(double c)
     {
-        return (float) ((c / 255.0f - 0.5) * 2.0f / Math.sqrt(2.0));
+        return ((c / 255.0f - 0.5) * 2.0f / Math.sqrt(2.0));
     }
 
 }

--- a/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/meta/Means.java
+++ b/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/meta/Means.java
@@ -34,12 +34,12 @@ public class Means
     /**
      * min of nx,ny,nz (log-domain)
      */
-    public float mins[];
+    public double mins[];
 
     /**
      * max of nx,ny,nz (log-domain)
      */
-    public float maxs[];
+    public double maxs[];
 
     /**
      * The files

--- a/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/meta/Scales.java
+++ b/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/meta/Scales.java
@@ -34,7 +34,7 @@ public class Scales
     /**
      * 256 floats; see §3.3
      */
-    public float codebook[];
+    public double codebook[];
 
     /**
      * The files

--- a/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/meta/Sh0.java
+++ b/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/meta/Sh0.java
@@ -34,7 +34,7 @@ public class Sh0
     /**
      * 256 floats; maps quantized DC to linear color (§3.4)
      */
-    public float codebook[];
+    public double codebook[];
 
     /**
      * The files

--- a/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/meta/ShN.java
+++ b/jsplat-io-sog/src/main/java/de/javagl/jsplat/io/sog/meta/ShN.java
@@ -44,7 +44,7 @@ public class ShN
     /**
      * 256 floats; shared for all AC coefficients (§3.5)
      */
-    public float codebook[];
+    public double codebook[];
 
     /**
      * The files

--- a/jsplat-io-spz/src/main/java/de/javagl/jsplat/io/spz/GaussianCloudSplats.java
+++ b/jsplat-io-spz/src/main/java/de/javagl/jsplat/io/spz/GaussianCloudSplats.java
@@ -133,24 +133,24 @@ public class GaussianCloudSplats
         {
             Splat splat = splats.get(i);
 
-            positions.put(i * 3 + 0, splat.getPositionX());
-            positions.put(i * 3 + 1, splat.getPositionY());
-            positions.put(i * 3 + 2, splat.getPositionZ());
+            positions.put(i * 3 + 0, (float)splat.getPositionX());
+            positions.put(i * 3 + 1, (float)splat.getPositionY());
+            positions.put(i * 3 + 2, (float)splat.getPositionZ());
 
-            scales.put(i * 3 + 0, splat.getScaleX());
-            scales.put(i * 3 + 1, splat.getScaleY());
-            scales.put(i * 3 + 2, splat.getScaleZ());
+            scales.put(i * 3 + 0, (float)splat.getScaleX());
+            scales.put(i * 3 + 1, (float)splat.getScaleY());
+            scales.put(i * 3 + 2, (float)splat.getScaleZ());
 
-            rotations.put(i * 4 + 0, splat.getRotationX());
-            rotations.put(i * 4 + 1, splat.getRotationY());
-            rotations.put(i * 4 + 2, splat.getRotationZ());
-            rotations.put(i * 4 + 3, splat.getRotationW());
+            rotations.put(i * 4 + 0, (float)splat.getRotationX());
+            rotations.put(i * 4 + 1, (float)splat.getRotationY());
+            rotations.put(i * 4 + 2, (float)splat.getRotationZ());
+            rotations.put(i * 4 + 3, (float)splat.getRotationW());
 
-            alphas.put(i, splat.getOpacity());
+            alphas.put(i, (float)splat.getOpacity());
 
-            colors.put(i * 3 + 0, splat.getShX(0));
-            colors.put(i * 3 + 1, splat.getShY(0));
-            colors.put(i * 3 + 2, splat.getShZ(0));
+            colors.put(i * 3 + 0, (float)splat.getShX(0));
+            colors.put(i * 3 + 1, (float)splat.getShY(0));
+            colors.put(i * 3 + 2, (float)splat.getShZ(0));
 
             if (shDimensions >= 4)
             {
@@ -162,9 +162,9 @@ public class GaussianCloudSplats
                     int iy = (index + d * 3) + 1;
                     int iz = (index + d * 3) + 2;
                     
-                    sh.put(ix, splat.getShX(d + 1));
-                    sh.put(iy, splat.getShY(d + 1));
-                    sh.put(iz, splat.getShZ(d + 1));
+                    sh.put(ix, (float)splat.getShX(d + 1));
+                    sh.put(iy, (float)splat.getShY(d + 1));
+                    sh.put(iz, (float)splat.getShZ(d + 1));
                 }
             }
         }

--- a/jsplat-processing/src/main/java/de/javagl/jsplat/processing/SphericalHarmonicsRotator.java
+++ b/jsplat-processing/src/main/java/de/javagl/jsplat/processing/SphericalHarmonicsRotator.java
@@ -31,7 +31,7 @@
  */
 package de.javagl.jsplat.processing;
 
-import java.nio.FloatBuffer;
+import java.nio.DoubleBuffer;
 
 /**
  * Internal class for rotating the spherical harmonics coefficients of splats.
@@ -40,7 +40,7 @@ import java.nio.FloatBuffer;
  * 
  * In contrast to the original implementation from "sh-lib", this is storing the
  * rotation matrices as fields, and offers a dedicated function to actually
- * {@link #rotate(FloatBuffer, FloatBuffer)} the coefficients for a single
+ * {@link #rotate(DoubleBuffer, DoubleBuffer)} the coefficients for a single
  * splat.
  * 
  * Internal note: See inlined comments of {@link SplatShRotator#rotateSh} for
@@ -49,47 +49,47 @@ import java.nio.FloatBuffer;
 @SuppressWarnings("javadoc")
 class SphericalHarmonicsRotator
 {
-    private static final float kSqrt03_02 = (float) Math.sqrt(3.0 / 2.0);
-    private static final float kSqrt01_03 = (float) Math.sqrt(1.0 / 3.0);
-    private static final float kSqrt02_03 = (float) Math.sqrt(2.0 / 3.0);
-    private static final float kSqrt04_03 = (float) Math.sqrt(4.0 / 3.0);
-    private static final float kSqrt01_04 = (float) Math.sqrt(1.0 / 4.0);
-    private static final float kSqrt03_04 = (float) Math.sqrt(3.0 / 4.0);
-    private static final float kSqrt01_05 = (float) Math.sqrt(1.0 / 5.0);
-    private static final float kSqrt03_05 = (float) Math.sqrt(3.0 / 5.0);
-    private static final float kSqrt06_05 = (float) Math.sqrt(6.0 / 5.0);
-    private static final float kSqrt08_05 = (float) Math.sqrt(8.0 / 5.0);
-    private static final float kSqrt09_05 = (float) Math.sqrt(9.0 / 5.0);
-    private static final float kSqrt01_06 = (float) Math.sqrt(1.0 / 6.0);
-    private static final float kSqrt05_06 = (float) Math.sqrt(5.0 / 6.0);
-    private static final float kSqrt03_08 = (float) Math.sqrt(3.0 / 8.0);
-    private static final float kSqrt05_08 = (float) Math.sqrt(5.0 / 8.0);
-    private static final float kSqrt09_08 = (float) Math.sqrt(9.0 / 8.0);
-    private static final float kSqrt05_09 = (float) Math.sqrt(5.0 / 9.0);
-    private static final float kSqrt08_09 = (float) Math.sqrt(8.0 / 9.0);
-    private static final float kSqrt01_10 = (float) Math.sqrt(1.0 / 10.0);
-    private static final float kSqrt03_10 = (float) Math.sqrt(3.0 / 10.0);
-    private static final float kSqrt01_12 = (float) Math.sqrt(1.0 / 12.0);
-    private static final float kSqrt04_15 = (float) Math.sqrt(4.0 / 15.0);
-    private static final float kSqrt01_16 = (float) Math.sqrt(1.0 / 16.0);
-    private static final float kSqrt15_16 = (float) Math.sqrt(15.0 / 16.0);
-    private static final float kSqrt01_18 = (float) Math.sqrt(1.0 / 18.0);
-    private static final float kSqrt01_60 = (float) Math.sqrt(1.0 / 60.0);
+    private static final double kSqrt03_02 = Math.sqrt(3.0 / 2.0);
+    private static final double kSqrt01_03 = Math.sqrt(1.0 / 3.0);
+    private static final double kSqrt02_03 = Math.sqrt(2.0 / 3.0);
+    private static final double kSqrt04_03 = Math.sqrt(4.0 / 3.0);
+    private static final double kSqrt01_04 = Math.sqrt(1.0 / 4.0);
+    private static final double kSqrt03_04 = Math.sqrt(3.0 / 4.0);
+    private static final double kSqrt01_05 = Math.sqrt(1.0 / 5.0);
+    private static final double kSqrt03_05 = Math.sqrt(3.0 / 5.0);
+    private static final double kSqrt06_05 = Math.sqrt(6.0 / 5.0);
+    private static final double kSqrt08_05 = Math.sqrt(8.0 / 5.0);
+    private static final double kSqrt09_05 = Math.sqrt(9.0 / 5.0);
+    private static final double kSqrt01_06 = Math.sqrt(1.0 / 6.0);
+    private static final double kSqrt05_06 = Math.sqrt(5.0 / 6.0);
+    private static final double kSqrt03_08 = Math.sqrt(3.0 / 8.0);
+    private static final double kSqrt05_08 = Math.sqrt(5.0 / 8.0);
+    private static final double kSqrt09_08 = Math.sqrt(9.0 / 8.0);
+    private static final double kSqrt05_09 = Math.sqrt(5.0 / 9.0);
+    private static final double kSqrt08_09 = Math.sqrt(8.0 / 9.0);
+    private static final double kSqrt01_10 = Math.sqrt(1.0 / 10.0);
+    private static final double kSqrt03_10 = Math.sqrt(3.0 / 10.0);
+    private static final double kSqrt01_12 = Math.sqrt(1.0 / 12.0);
+    private static final double kSqrt04_15 = Math.sqrt(4.0 / 15.0);
+    private static final double kSqrt01_16 = Math.sqrt(1.0 / 16.0);
+    private static final double kSqrt15_16 = Math.sqrt(15.0 / 16.0);
+    private static final double kSqrt01_18 = Math.sqrt(1.0 / 18.0);
+    private static final double kSqrt01_60 = Math.sqrt(1.0 / 60.0);
 
     /**
      * The 3x3 matrix for rotating the dimensions for the first degree
      */
-    private final float sh1[][];
+    private final double sh1[][];
 
     /**
      * The 5x5 matrix for rotating the dimensions of the second degree
      */
-    private final float sh2[][];
+    private final double sh2[][];
 
     /**
      * The 7x7 matrix for rotating the dimensions of the third degree
      */
-    private final float sh3[][];
+    private final double sh3[][];
 
     /**
      * Creates a new instance for the given matrix.
@@ -99,70 +99,70 @@ class SphericalHarmonicsRotator
      * 
      * @param rot The rotation matrix
      */
-    SphericalHarmonicsRotator(float rot[])
+    SphericalHarmonicsRotator(double rot[])
     {
-        this.sh1 = new float[][]
+        this.sh1 = new double[][]
         {
             { rot[4], -rot[7], rot[1] },
             { -rot[5], rot[8], -rot[2] },
             { rot[3], -rot[6], rot[0] } };
 
-        float sh1_0_0 = sh1[0][0];
-        float sh1_0_1 = sh1[0][1];
-        float sh1_0_2 = sh1[0][2];
-        float sh1_1_0 = sh1[1][0];
-        float sh1_1_1 = sh1[1][1];
-        float sh1_1_2 = sh1[1][2];
-        float sh1_2_0 = sh1[2][0];
-        float sh1_2_1 = sh1[2][1];
-        float sh1_2_2 = sh1[2][2];
+        double sh1_0_0 = sh1[0][0];
+        double sh1_0_1 = sh1[0][1];
+        double sh1_0_2 = sh1[0][2];
+        double sh1_1_0 = sh1[1][0];
+        double sh1_1_1 = sh1[1][1];
+        double sh1_1_2 = sh1[1][2];
+        double sh1_2_0 = sh1[2][0];
+        double sh1_2_1 = sh1[2][1];
+        double sh1_2_2 = sh1[2][2];
 
-        float sh2_0_0 = kSqrt01_04 * ((sh1_2_2 * sh1_0_0 + sh1_2_0 * sh1_0_2)
+        double sh2_0_0 = kSqrt01_04 * ((sh1_2_2 * sh1_0_0 + sh1_2_0 * sh1_0_2)
             + (sh1_0_2 * sh1_2_0 + sh1_0_0 * sh1_2_2));
-        float sh2_0_1 = sh1_2_1 * sh1_0_0 + sh1_0_1 * sh1_2_0;
-        float sh2_0_2 = kSqrt03_04 * (sh1_2_1 * sh1_0_1 + sh1_0_1 * sh1_2_1);
-        float sh2_0_3 = sh1_2_1 * sh1_0_2 + sh1_0_1 * sh1_2_2;
-        float sh2_0_4 = kSqrt01_04 * ((sh1_2_2 * sh1_0_2 - sh1_2_0 * sh1_0_0)
+        double sh2_0_1 = sh1_2_1 * sh1_0_0 + sh1_0_1 * sh1_2_0;
+        double sh2_0_2 = kSqrt03_04 * (sh1_2_1 * sh1_0_1 + sh1_0_1 * sh1_2_1);
+        double sh2_0_3 = sh1_2_1 * sh1_0_2 + sh1_0_1 * sh1_2_2;
+        double sh2_0_4 = kSqrt01_04 * ((sh1_2_2 * sh1_0_2 - sh1_2_0 * sh1_0_0)
             + (sh1_0_2 * sh1_2_2 - sh1_0_0 * sh1_2_0));
 
-        float sh2_1_0 = kSqrt01_04 * ((sh1_1_2 * sh1_0_0 + sh1_1_0 * sh1_0_2)
+        double sh2_1_0 = kSqrt01_04 * ((sh1_1_2 * sh1_0_0 + sh1_1_0 * sh1_0_2)
             + (sh1_0_2 * sh1_1_0 + sh1_0_0 * sh1_1_2));
-        float sh2_1_1 = sh1_1_1 * sh1_0_0 + sh1_0_1 * sh1_1_0;
-        float sh2_1_2 = kSqrt03_04 * (sh1_1_1 * sh1_0_1 + sh1_0_1 * sh1_1_1);
-        float sh2_1_3 = sh1_1_1 * sh1_0_2 + sh1_0_1 * sh1_1_2;
-        float sh2_1_4 = kSqrt01_04 * ((sh1_1_2 * sh1_0_2 - sh1_1_0 * sh1_0_0)
+        double sh2_1_1 = sh1_1_1 * sh1_0_0 + sh1_0_1 * sh1_1_0;
+        double sh2_1_2 = kSqrt03_04 * (sh1_1_1 * sh1_0_1 + sh1_0_1 * sh1_1_1);
+        double sh2_1_3 = sh1_1_1 * sh1_0_2 + sh1_0_1 * sh1_1_2;
+        double sh2_1_4 = kSqrt01_04 * ((sh1_1_2 * sh1_0_2 - sh1_1_0 * sh1_0_0)
             + (sh1_0_2 * sh1_1_2 - sh1_0_0 * sh1_1_0));
 
-        float sh2_2_0 = kSqrt01_03 * (sh1_1_2 * sh1_1_0 + sh1_1_0 * sh1_1_2)
+        double sh2_2_0 = kSqrt01_03 * (sh1_1_2 * sh1_1_0 + sh1_1_0 * sh1_1_2)
             - kSqrt01_12 * ((sh1_2_2 * sh1_2_0 + sh1_2_0 * sh1_2_2)
                 + (sh1_0_2 * sh1_0_0 + sh1_0_0 * sh1_0_2));
-        float sh2_2_1 = kSqrt04_03 * sh1_1_1 * sh1_1_0
+        double sh2_2_1 = kSqrt04_03 * sh1_1_1 * sh1_1_0
             - kSqrt01_03 * (sh1_2_1 * sh1_2_0 + sh1_0_1 * sh1_0_0);
-        float sh2_2_2 = sh1_1_1 * sh1_1_1
+        double sh2_2_2 = sh1_1_1 * sh1_1_1
             - kSqrt01_04 * (sh1_2_1 * sh1_2_1 + sh1_0_1 * sh1_0_1);
-        float sh2_2_3 = kSqrt04_03 * sh1_1_1 * sh1_1_2
+        double sh2_2_3 = kSqrt04_03 * sh1_1_1 * sh1_1_2
             - kSqrt01_03 * (sh1_2_1 * sh1_2_2 + sh1_0_1 * sh1_0_2);
-        float sh2_2_4 = kSqrt01_03 * (sh1_1_2 * sh1_1_2 - sh1_1_0 * sh1_1_0)
+        double sh2_2_4 = kSqrt01_03 * (sh1_1_2 * sh1_1_2 - sh1_1_0 * sh1_1_0)
             - kSqrt01_12 * ((sh1_2_2 * sh1_2_2 - sh1_2_0 * sh1_2_0)
                 + (sh1_0_2 * sh1_0_2 - sh1_0_0 * sh1_0_0));
 
-        float sh2_3_0 = kSqrt01_04 * ((sh1_1_2 * sh1_2_0 + sh1_1_0 * sh1_2_2)
+        double sh2_3_0 = kSqrt01_04 * ((sh1_1_2 * sh1_2_0 + sh1_1_0 * sh1_2_2)
             + (sh1_2_2 * sh1_1_0 + sh1_2_0 * sh1_1_2));
-        float sh2_3_1 = sh1_1_1 * sh1_2_0 + sh1_2_1 * sh1_1_0;
-        float sh2_3_2 = kSqrt03_04 * (sh1_1_1 * sh1_2_1 + sh1_2_1 * sh1_1_1);
-        float sh2_3_3 = sh1_1_1 * sh1_2_2 + sh1_2_1 * sh1_1_2;
-        float sh2_3_4 = kSqrt01_04 * ((sh1_1_2 * sh1_2_2 - sh1_1_0 * sh1_2_0)
+        double sh2_3_1 = sh1_1_1 * sh1_2_0 + sh1_2_1 * sh1_1_0;
+        double sh2_3_2 = kSqrt03_04 * (sh1_1_1 * sh1_2_1 + sh1_2_1 * sh1_1_1);
+        double sh2_3_3 = sh1_1_1 * sh1_2_2 + sh1_2_1 * sh1_1_2;
+        double sh2_3_4 = kSqrt01_04 * ((sh1_1_2 * sh1_2_2 - sh1_1_0 * sh1_2_0)
             + (sh1_2_2 * sh1_1_2 - sh1_2_0 * sh1_1_0));
 
-        float sh2_4_0 = kSqrt01_04 * ((sh1_2_2 * sh1_2_0 + sh1_2_0 * sh1_2_2)
+        double sh2_4_0 = kSqrt01_04 * ((sh1_2_2 * sh1_2_0 + sh1_2_0 * sh1_2_2)
             - (sh1_0_2 * sh1_0_0 + sh1_0_0 * sh1_0_2));
-        float sh2_4_1 = sh1_2_1 * sh1_2_0 - sh1_0_1 * sh1_0_0;
-        float sh2_4_2 = kSqrt03_04 * (sh1_2_1 * sh1_2_1 - sh1_0_1 * sh1_0_1);
-        float sh2_4_3 = sh1_2_1 * sh1_2_2 - sh1_0_1 * sh1_0_2;
-        float sh2_4_4 = kSqrt01_04 * ((sh1_2_2 * sh1_2_2 - sh1_2_0 * sh1_2_0)
+        double sh2_4_1 = sh1_2_1 * sh1_2_0 - sh1_0_1 * sh1_0_0;
+        double sh2_4_2 = kSqrt03_04 * (sh1_2_1 * sh1_2_1 - sh1_0_1 * sh1_0_1);
+        double sh2_4_3 = sh1_2_1 * sh1_2_2 - sh1_0_1 * sh1_0_2;
+        double sh2_4_4 = kSqrt01_04 * ((sh1_2_2 * sh1_2_2 - sh1_2_0 * sh1_2_0)
             - (sh1_0_2 * sh1_0_2 - sh1_0_0 * sh1_0_0));
 
-        this.sh2 = new float[][]
+        this.sh2 = new double[][]
         {
             { sh2_0_0, sh2_0_1, sh2_0_2, sh2_0_3, sh2_0_4 },
             { sh2_1_0, sh2_1_1, sh2_1_2, sh2_1_3, sh2_1_4 },
@@ -170,7 +170,7 @@ class SphericalHarmonicsRotator
             { sh2_3_0, sh2_3_1, sh2_3_2, sh2_3_3, sh2_3_4 },
             { sh2_4_0, sh2_4_1, sh2_4_2, sh2_4_3, sh2_4_4 } };
 
-        this.sh3 = new float[][]
+        this.sh3 = new double[][]
         {
             { kSqrt01_04 * ((sh1_2_2 * sh2_0_0 + sh1_2_0 * sh2_0_4)
                 + (sh1_0_2 * sh2_4_0 + sh1_0_0 * sh2_4_4)),
@@ -281,7 +281,7 @@ class SphericalHarmonicsRotator
      * @param coeffsIn The input buffer
      * @param coeffs The output
      */
-    void rotate(FloatBuffer coeffsIn, FloatBuffer coeffs)
+    void rotate(DoubleBuffer coeffsIn, DoubleBuffer coeffs)
     {
 
         int i = 0;
@@ -322,14 +322,14 @@ class SphericalHarmonicsRotator
      * buffer, and the given array.
      * 
      * @param n The number of dimensions
-     * @param a The float buffer
-     * @param offset The offset inside the float buffer
+     * @param a The double buffer
+     * @param offset The offset inside the double buffer
      * @param b The array
      * @return The dot product
      */
-    private static float dp(int n, FloatBuffer a, int offset, float b[])
+    private static double dp(int n, DoubleBuffer a, int offset, double b[])
     {
-        float result = 0.0f;
+        double result = 0.0f;
         for (int i = 0; i < n; i++)
         {
             result += a.get(offset + i) * b[i];

--- a/jsplat-processing/src/main/java/de/javagl/jsplat/processing/SplatComparing.java
+++ b/jsplat-processing/src/main/java/de/javagl/jsplat/processing/SplatComparing.java
@@ -42,21 +42,21 @@ public class SplatComparing
      * @param s1 The second splat
      * @return The result
      */
-    public static float squaredDistanceByPosition(Splat s0, Splat s1)
+    public static double squaredDistanceByPosition(Splat s0, Splat s1)
     {
-        float px0 = s0.getPositionX();
-        float py0 = s0.getPositionY();
-        float pz0 = s0.getPositionZ();
+        double px0 = s0.getPositionX();
+        double py0 = s0.getPositionY();
+        double pz0 = s0.getPositionZ();
 
-        float px1 = s1.getPositionX();
-        float py1 = s1.getPositionY();
-        float pz1 = s1.getPositionZ();
+        double px1 = s1.getPositionX();
+        double py1 = s1.getPositionY();
+        double pz1 = s1.getPositionZ();
 
-        float dpx = px0 - px1;
-        float dpy = py0 - py1;
-        float dpz = pz0 - pz1;
+        double dpx = px0 - px1;
+        double dpy = py0 - py1;
+        double dpz = pz0 - pz1;
         
-        float squaredDistance = dpx * dpx + dpy * dpy + dpz * dpz;
+        double squaredDistance = dpx * dpx + dpy * dpy + dpz * dpz;
         return squaredDistance;
     }
 
@@ -67,10 +67,10 @@ public class SplatComparing
      * @param s1 The second splat
      * @return The result
      */
-    static float distanceByPosition(Splat s0, Splat s1)
+    static double distanceByPosition(Splat s0, Splat s1)
     {
-        float dd = squaredDistanceByPosition(s0, s1);
-        float d = (float) Math.sqrt(dd);
+        double dd = squaredDistanceByPosition(s0, s1);
+        double d = Math.sqrt(dd);
         return d;
     }
 
@@ -85,24 +85,24 @@ public class SplatComparing
      */
     static int compareByImportance(Splat s0, Splat s1)
     {
-        float sx0 = (float) Math.exp(s0.getScaleX());
-        float sy0 = (float) Math.exp(s0.getScaleY());
-        float sz0 = (float) Math.exp(s0.getScaleZ());
+        double sx0 = Math.exp(s0.getScaleX());
+        double sy0 = Math.exp(s0.getScaleY());
+        double sz0 = Math.exp(s0.getScaleZ());
 
-        float sx1 = (float) Math.exp(s1.getScaleX());
-        float sy1 = (float) Math.exp(s1.getScaleY());
-        float sz1 = (float) Math.exp(s1.getScaleZ());
+        double sx1 = Math.exp(s1.getScaleX());
+        double sy1 = Math.exp(s1.getScaleY());
+        double sz1 = Math.exp(s1.getScaleZ());
 
-        float volume0 = sx0 * sy0 * sz0;
-        float volume1 = sx1 * sy1 * sz1;
+        double volume0 = sx0 * sy0 * sz0;
+        double volume1 = sx1 * sy1 * sz1;
 
-        float o0 = s0.getOpacity();
-        float o1 = s1.getOpacity();
+        double o0 = s0.getOpacity();
+        double o1 = s1.getOpacity();
 
-        float importance0 = volume0 * o0;
-        float importance1 = volume1 * o1;
+        double importance0 = volume0 * o0;
+        double importance1 = volume1 * o1;
 
-        return Float.compare(importance0, importance1);
+        return Double.compare(importance0, importance1);
     }
 
     /**
@@ -118,17 +118,17 @@ public class SplatComparing
      */
     static int compareByVolumeLinear(Splat s0, Splat s1)
     {
-        float sx0 = (float) Math.exp(s0.getScaleX());
-        float sy0 = (float) Math.exp(s0.getScaleY());
-        float sz0 = (float) Math.exp(s0.getScaleZ());
+        double sx0 = Math.exp(s0.getScaleX());
+        double sy0 = Math.exp(s0.getScaleY());
+        double sz0 = Math.exp(s0.getScaleZ());
 
-        float sx1 = (float) Math.exp(s1.getScaleX());
-        float sy1 = (float) Math.exp(s1.getScaleY());
-        float sz1 = (float) Math.exp(s1.getScaleZ());
+        double sx1 = Math.exp(s1.getScaleX());
+        double sy1 = Math.exp(s1.getScaleY());
+        double sz1 = Math.exp(s1.getScaleZ());
 
-        float volume0 = sx0 * sy0 * sz0;
-        float volume1 = sx1 * sy1 * sz1;
-        return Float.compare(volume0, volume1);
+        double volume0 = sx0 * sy0 * sz0;
+        double volume1 = sx1 * sy1 * sz1;
+        return Double.compare(volume0, volume1);
     }
 
     /**
@@ -141,17 +141,17 @@ public class SplatComparing
      */
     static int compareByMaxScale(Splat s0, Splat s1)
     {
-        float sx0 = s0.getScaleX();
-        float sy0 = s0.getScaleY();
-        float sz0 = s0.getScaleZ();
+        double sx0 = s0.getScaleX();
+        double sy0 = s0.getScaleY();
+        double sz0 = s0.getScaleZ();
 
-        float sx1 = s1.getScaleX();
-        float sy1 = s1.getScaleY();
-        float sz1 = s1.getScaleZ();
+        double sx1 = s1.getScaleX();
+        double sy1 = s1.getScaleY();
+        double sz1 = s1.getScaleZ();
 
-        float maxScale0 = Math.max(sx0, Math.max(sy0, sz0));
-        float maxScale1 = Math.max(sx1, Math.max(sy1, sz1));
-        return Float.compare(maxScale0, maxScale1);
+        double maxScale0 = Math.max(sx0, Math.max(sy0, sz0));
+        double maxScale1 = Math.max(sx1, Math.max(sy1, sz1));
+        return Double.compare(maxScale0, maxScale1);
     }
 
     /**

--- a/jsplat-processing/src/main/java/de/javagl/jsplat/processing/SplatPositionTransformer.java
+++ b/jsplat-processing/src/main/java/de/javagl/jsplat/processing/SplatPositionTransformer.java
@@ -36,7 +36,7 @@ class SplatPositionTransformer
     /**
      * The transform matrix
      */
-    private final float matrix4[];
+    private final double matrix4[];
 
     /**
      * Creates a new instance for the given matrix.
@@ -49,7 +49,7 @@ class SplatPositionTransformer
      * 
      * @param matrix4 The matrix
      */
-    SplatPositionTransformer(float matrix4[])
+    SplatPositionTransformer(double matrix4[])
     {
         this.matrix4 = matrix4;
     }
@@ -61,13 +61,13 @@ class SplatPositionTransformer
      */
     void transform(MutableSplat s)
     {
-        float m[] = matrix4;
-        float x = s.getPositionX();
-        float y = s.getPositionY();
-        float z = s.getPositionZ();
-        float rx = m[0] * x + m[4] * y + m[8] * z + m[12];
-        float ry = m[1] * x + m[5] * y + m[9] * z + m[13];
-        float rz = m[2] * x + m[6] * y + m[10] * z + m[14];
+        double m[] = matrix4;
+        double x = s.getPositionX();
+        double y = s.getPositionY();
+        double z = s.getPositionZ();
+        double rx = m[0] * x + m[4] * y + m[8] * z + m[12];
+        double ry = m[1] * x + m[5] * y + m[9] * z + m[13];
+        double rz = m[2] * x + m[6] * y + m[10] * z + m[14];
         s.setPositionX(rx);
         s.setPositionY(ry);
         s.setPositionZ(rz);

--- a/jsplat-processing/src/main/java/de/javagl/jsplat/processing/SplatRotationRotator.java
+++ b/jsplat-processing/src/main/java/de/javagl/jsplat/processing/SplatRotationRotator.java
@@ -36,7 +36,7 @@ class SplatRotationRotator
     /**
      * The quaternion for the rotation
      */
-    private final float rotationQuaternion[];
+    private final double rotationQuaternion[];
 
     /**
      * Creates a new instance for the given scalar-last quaternion.
@@ -46,7 +46,7 @@ class SplatRotationRotator
      * 
      * @param rotationQuaternion The rotation quaternion
      */
-    SplatRotationRotator(float rotationQuaternion[])
+    SplatRotationRotator(double rotationQuaternion[])
     {
         this.rotationQuaternion = rotationQuaternion;
     }
@@ -58,20 +58,20 @@ class SplatRotationRotator
      */
     void rotate(MutableSplat s)
     {
-        float q0x = rotationQuaternion[0];
-        float q0y = rotationQuaternion[1];
-        float q0z = rotationQuaternion[2];
-        float q0w = rotationQuaternion[3];
+        double q0x = rotationQuaternion[0];
+        double q0y = rotationQuaternion[1];
+        double q0z = rotationQuaternion[2];
+        double q0w = rotationQuaternion[3];
 
-        float q1x = s.getRotationX();
-        float q1y = s.getRotationY();
-        float q1z = s.getRotationZ();
-        float q1w = s.getRotationW();
+        double q1x = s.getRotationX();
+        double q1y = s.getRotationY();
+        double q1z = s.getRotationZ();
+        double q1w = s.getRotationW();
 
-        float rx = q0w * q1x + q0x * q1w + q0y * q1z - q0z * q1y;
-        float ry = q0w * q1y - q0x * q1z + q0y * q1w + q0z * q1x;
-        float rz = q0w * q1z + q0x * q1y - q0y * q1x + q0z * q1w;
-        float rw = q0w * q1w - q0x * q1x - q0y * q1y - q0z * q1z;
+        double rx = q0w * q1x + q0x * q1w + q0y * q1z - q0z * q1y;
+        double ry = q0w * q1y - q0x * q1z + q0y * q1w + q0z * q1x;
+        double rz = q0w * q1z + q0x * q1y - q0y * q1x + q0z * q1w;
+        double rw = q0w * q1w - q0x * q1x - q0y * q1y - q0z * q1z;
 
         s.setRotationX(rx);
         s.setRotationY(ry);

--- a/jsplat-processing/src/main/java/de/javagl/jsplat/processing/SplatScaleScaler.java
+++ b/jsplat-processing/src/main/java/de/javagl/jsplat/processing/SplatScaleScaler.java
@@ -36,17 +36,17 @@ class SplatScaleScaler
     /**
      * The scale factor along x
      */
-    private final float sx;
+    private final double sx;
 
     /**
      * The scale factor along y
      */
-    private final float sy;
+    private final double sy;
 
     /**
      * The scale factor along z
      */
-    private final float sz;
+    private final double sz;
 
     /**
      * Creates a new instance
@@ -55,7 +55,7 @@ class SplatScaleScaler
      * @param sy The scaling along y
      * @param sz The scaling along z
      */
-    SplatScaleScaler(float sx, float sy, float sz)
+    SplatScaleScaler(double sx, double sy, double sz)
     {
         this.sx = sx;
         this.sy = sy;
@@ -69,9 +69,9 @@ class SplatScaleScaler
      */
     void scale(MutableSplat s)
     {
-        s.setScaleX((float)Math.log(Math.exp(s.getScaleX()) * sx));
-        s.setScaleY((float)Math.log(Math.exp(s.getScaleY()) * sy));
-        s.setScaleZ((float)Math.log(Math.exp(s.getScaleZ()) * sz));
+        s.setScaleX(Math.log(Math.exp(s.getScaleX()) * sx));
+        s.setScaleY(Math.log(Math.exp(s.getScaleY()) * sy));
+        s.setScaleZ(Math.log(Math.exp(s.getScaleZ()) * sz));
     }
 
 }

--- a/jsplat-processing/src/main/java/de/javagl/jsplat/processing/SplatShRotator.java
+++ b/jsplat-processing/src/main/java/de/javagl/jsplat/processing/SplatShRotator.java
@@ -26,7 +26,7 @@
  */
 package de.javagl.jsplat.processing;
 
-import java.nio.FloatBuffer;
+import java.nio.DoubleBuffer;
 
 import de.javagl.jsplat.MutableSplat;
 
@@ -38,12 +38,12 @@ class SplatShRotator
     /**
      * A thread-local buffer for the input coefficients
      */
-    private final ThreadLocal<FloatBuffer> threadLocalCoeffsIn;
+    private final ThreadLocal<DoubleBuffer> threadLocalCoeffsIn;
 
     /**
      * A thread-local buffer for the coefficients
      */
-    private final ThreadLocal<FloatBuffer> threadLocalCoeffs;
+    private final ThreadLocal<DoubleBuffer> threadLocalCoeffs;
     
     /**
      * The {@link SphericalHarmonicsRotator}
@@ -60,12 +60,12 @@ class SplatShRotator
      * @param matrix The matrix
      * @param dims The dimensions
      */
-    SplatShRotator(float matrix[], int dims)
+    SplatShRotator(double matrix[], int dims)
     {
         this.threadLocalCoeffsIn =
-            ThreadLocal.withInitial(() -> FloatBuffer.allocate(dims - 1));
+            ThreadLocal.withInitial(() -> DoubleBuffer.allocate(dims - 1));
         this.threadLocalCoeffs =
-            ThreadLocal.withInitial(() -> FloatBuffer.allocate(dims - 1));
+            ThreadLocal.withInitial(() -> DoubleBuffer.allocate(dims - 1));
         this.sr = new SphericalHarmonicsRotator(matrix);
     }
     
@@ -104,8 +104,8 @@ class SplatShRotator
         
         int dims = s.getShDimensions();
         
-        FloatBuffer coeffsIn = threadLocalCoeffsIn.get();
-        FloatBuffer coeffs = threadLocalCoeffs.get();
+        DoubleBuffer coeffsIn = threadLocalCoeffsIn.get();
+        DoubleBuffer coeffs = threadLocalCoeffs.get();
 
         // Coefficients for X
         for (int d = 0; d < dims - 1; d++)

--- a/jsplat-processing/src/main/java/de/javagl/jsplat/processing/SplatTransforms.java
+++ b/jsplat-processing/src/main/java/de/javagl/jsplat/processing/SplatTransforms.java
@@ -52,7 +52,7 @@ public class SplatTransforms
      * @return The given list
      */
     public static <T extends MutableSplat> List<T> transformList(List<T> list,
-        float matrix4[])
+        double matrix4[])
     {
         if (list.isEmpty()) 
         {
@@ -74,12 +74,12 @@ public class SplatTransforms
      * @param dims The splat dimensions
      * @return The transform
      */
-    public static Consumer<MutableSplat> createTransform(float matrix4[],
+    public static Consumer<MutableSplat> createTransform(double matrix4[],
         int dims)
     {
-        float scales[] = VecMath.computeScales(matrix4, null);
-        float matrix3[] = VecMath.extractRotation(matrix4, scales, null);
-        float rotation[] =
+        double scales[] = VecMath.computeScales(matrix4, null);
+        double matrix3[] = VecMath.extractRotation(matrix4, scales, null);
+        double rotation[] =
             VecMath.rotationMatrixToScalarLastQuaternion(matrix3, null);
         SplatPositionTransformer pt = new SplatPositionTransformer(matrix4);
         SplatRotationRotator rr = new SplatRotationRotator(rotation);
@@ -108,7 +108,7 @@ public class SplatTransforms
      * @return The given list
      */
     public static <T extends MutableSplat> List<T> translateList(List<T> list,
-        float dx, float dy, float dz)
+        double dx, double dy, double dz)
     {
         list.stream().parallel().forEach(s -> translate(s, dx, dy, dz));
         return list;
@@ -121,17 +121,17 @@ public class SplatTransforms
      */
     private static void normalizeRotationQuaternion(MutableSplat s)
     {
-        float rX = s.getRotationX();
-        float rY = s.getRotationY();
-        float rZ = s.getRotationZ();
-        float rW = s.getRotationW();
-        float lenSquared = rX * rX + rY * rY + rZ * rZ + rW * rW;
-        if (Math.abs(1.0f - lenSquared) < 1e-6)
+        double rX = s.getRotationX();
+        double rY = s.getRotationY();
+        double rZ = s.getRotationZ();
+        double rW = s.getRotationW();
+        double lenSquared = rX * rX + rY * rY + rZ * rZ + rW * rW;
+        if (Math.abs(1.0 - lenSquared) < 1e-6)
         {
             return;
         }
-        float len = (float) Math.sqrt(lenSquared);
-        float invLen = 1.0f / len;
+        double len = Math.sqrt(lenSquared);
+        double invLen = 1.0 / len;
         s.setRotationX(rX * invLen);
         s.setRotationY(rY * invLen);
         s.setRotationZ(rZ * invLen);
@@ -146,7 +146,7 @@ public class SplatTransforms
      * @param dy The translation in y-direction
      * @param dz The translation in z-direction
      */
-    private static void translate(MutableSplat s, float dx, float dy, float dz)
+    private static void translate(MutableSplat s, double dx, double dy, double dz)
     {
         s.setPositionX(s.getPositionX() + dx);
         s.setPositionY(s.getPositionY() + dy);
@@ -162,8 +162,8 @@ public class SplatTransforms
      * @param sz The scale in z-direction
      * @return The given list
      */
-    static <T extends MutableSplat> List<T> scaleList(List<T> list, float sx,
-        float sy, float sz)
+    static <T extends MutableSplat> List<T> scaleList(List<T> list, double sx,
+        double sy, double sz)
     {
         list.stream().parallel().forEach(s -> scale(s, sx, sy, sz));
         return list;
@@ -177,11 +177,11 @@ public class SplatTransforms
      * @param sy The scale in y-direction
      * @param sz The scale in z-direction
      */
-    private static void scale(MutableSplat s, float sx, float sy, float sz)
+    private static void scale(MutableSplat s, double sx, double sy, double sz)
     {
-        s.setScaleX((float) Math.log(Math.exp(s.getScaleX()) * sx));
-        s.setScaleY((float) Math.log(Math.exp(s.getScaleY()) * sy));
-        s.setScaleZ((float) Math.log(Math.exp(s.getScaleZ()) * sz));
+        s.setScaleX(Math.log(Math.exp(s.getScaleX()) * sx));
+        s.setScaleY(Math.log(Math.exp(s.getScaleY()) * sy));
+        s.setScaleZ(Math.log(Math.exp(s.getScaleZ()) * sz));
     }
 
     /**

--- a/jsplat-processing/src/main/java/de/javagl/jsplat/processing/VecMath.java
+++ b/jsplat-processing/src/main/java/de/javagl/jsplat/processing/VecMath.java
@@ -39,7 +39,7 @@ public class VecMath
     /**
      * Epsilon for quaternion computations
      */
-    private static final float EPSILON = 1e-6f;
+    private static final double EPSILON = 1e-6;
 
     /**
      * Compute the scaling factors from the given 4x4 matrix.
@@ -51,23 +51,23 @@ public class VecMath
      * @param result The result
      * @return The result
      */
-    static float[] computeScales(float matrix4[], float result[])
+    static double[] computeScales(double matrix4[], double result[])
     {
-        float r[] = validate(result, 3);
+        double r[] = validate(result, 3);
 
-        float m00 = matrix4[0];
-        float m10 = matrix4[1];
-        float m20 = matrix4[2];
-        float m01 = matrix4[4];
-        float m11 = matrix4[5];
-        float m21 = matrix4[6];
-        float m02 = matrix4[8];
-        float m12 = matrix4[9];
-        float m22 = matrix4[10];
+        double m00 = matrix4[0];
+        double m10 = matrix4[1];
+        double m20 = matrix4[2];
+        double m01 = matrix4[4];
+        double m11 = matrix4[5];
+        double m21 = matrix4[6];
+        double m02 = matrix4[8];
+        double m12 = matrix4[9];
+        double m22 = matrix4[10];
 
-        r[0] = (float) Math.sqrt(m00 * m00 + m10 * m10 + m20 * m20);
-        r[1] = (float) Math.sqrt(m01 * m01 + m11 * m11 + m21 * m21);
-        r[2] = (float) Math.sqrt(m02 * m02 + m12 * m12 + m22 * m22);
+        r[0] = Math.sqrt(m00 * m00 + m10 * m10 + m20 * m20);
+        r[1] = Math.sqrt(m01 * m01 + m11 * m11 + m21 * m21);
+        r[2] = Math.sqrt(m02 * m02 + m12 * m12 + m22 * m22);
         return r;
     }
 
@@ -86,10 +86,10 @@ public class VecMath
      * @param result The result
      * @return The result
      */
-    static float[] extractRotation(float[] matrix4, float[] scales,
-        float result[])
+    static double[] extractRotation(double[] matrix4, double[] scales,
+        double result[])
     {
-        float r[] = validate(result, 9);
+        double r[] = validate(result, 9);
 
         r[0] = matrix4[0] / scales[0];
         r[1] = matrix4[1] / scales[0];
@@ -116,35 +116,35 @@ public class VecMath
      * @param result The result
      * @return The result
      */
-    static float[] rotationMatrixToScalarLastQuaternion(float[] matrix3,
-        float result[])
+    static double[] rotationMatrixToScalarLastQuaternion(double[] matrix3,
+        double result[])
     {
-        float r[] = validate(result, 4);
+        double r[] = validate(result, 4);
 
-        float m00 = matrix3[0];
-        float m01 = matrix3[3];
-        float m02 = matrix3[6];
-        float m10 = matrix3[1];
-        float m11 = matrix3[4];
-        float m12 = matrix3[7];
-        float m20 = matrix3[2];
-        float m21 = matrix3[5];
-        float m22 = matrix3[8];
+        double m00 = matrix3[0];
+        double m01 = matrix3[3];
+        double m02 = matrix3[6];
+        double m10 = matrix3[1];
+        double m11 = matrix3[4];
+        double m12 = matrix3[7];
+        double m20 = matrix3[2];
+        double m21 = matrix3[5];
+        double m22 = matrix3[8];
 
-        float trace = m00 + m11 + m22;
-        if (trace > 0.0f)
+        double trace = m00 + m11 + m22;
+        if (trace > 0.0)
         {
-            float S = (float) Math.sqrt(trace + 1.0f) * 2f;
+            double S = Math.sqrt(trace + 1.0) * 2.0;
             r[0] = (m21 - m12) / S;
             r[1] = (m02 - m20) / S;
             r[2] = (m10 - m01) / S;
-            r[3] = 0.25f * S;
+            r[3] = 0.25 * S;
             return r;
         }
         if ((m00 > m11) && (m00 > m22))
         {
-            float S = (float) Math.sqrt(1.0f + m00 - m11 - m22) * 2f;
-            r[0] = 0.25f * S;
+            double S = Math.sqrt(1.0 + m00 - m11 - m22) * 2.0;
+            r[0] = 0.25 * S;
             r[1] = (m01 + m10) / S;
             r[2] = (m02 + m20) / S;
             r[3] = (m21 - m12) / S;
@@ -152,17 +152,17 @@ public class VecMath
         }
         if (m11 > m22)
         {
-            float S = (float) Math.sqrt(1.0f + m11 - m00 - m22) * 2f;
+            double S = Math.sqrt(1.0 + m11 - m00 - m22) * 2.0;
             r[0] = (m01 + m10) / S;
-            r[1] = 0.25f * S;
+            r[1] = 0.25 * S;
             r[2] = (m12 + m21) / S;
             r[3] = (m02 - m20) / S;
             return r;
         }
-        float S = (float) Math.sqrt(1.0f + m22 - m00 - m11) * 2f;
+        double S = Math.sqrt(1.0 + m22 - m00 - m11) * 2.0;
         r[0] = (m02 + m20) / S;
         r[1] = (m12 + m21) / S;
-        r[2] = 0.25f * S;
+        r[2] = 0.25 * S;
         r[3] = (m10 - m01) / S;
         return r;
     }
@@ -178,25 +178,25 @@ public class VecMath
      * @param result The result
      * @return The result
      */
-    static float[] scalarLastQuaternionToRotationMatrix(float q[],
-        float result[])
+    static double[] scalarLastQuaternionToRotationMatrix(double q[],
+        double result[])
     {
-        float r[] = validate(result, 9);
+        double r[] = validate(result, 9);
 
-        float qx = q[0];
-        float qy = q[1];
-        float qz = q[2];
-        float qw = q[3];
+        double qx = q[0];
+        double qy = q[1];
+        double qz = q[2];
+        double qw = q[3];
 
-        float xx = qx * qx;
-        float yy = qy * qy;
-        float zz = qz * qz;
-        float xy = qx * qy;
-        float xz = qx * qz;
-        float xw = qx * qw;
-        float yz = qy * qz;
-        float yw = qy * qw;
-        float zw = qz * qw;
+        double xx = qx * qx;
+        double yy = qy * qy;
+        double zz = qz * qz;
+        double xy = qx * qy;
+        double xz = qx * qz;
+        double xw = qx * qw;
+        double yz = qy * qz;
+        double yw = qy * qw;
+        double zw = qz * qw;
 
         r[0] = 1 - 2 * (yy + zz);
         r[1] = 2 * (xy + zw);
@@ -223,19 +223,19 @@ public class VecMath
      * @param result The result
      * @return The result
      */
-    static float[] multiplyScalarLastQuaternions(float[] q0, float[] q1,
-        float result[])
+    static double[] multiplyScalarLastQuaternions(double[] q0, double[] q1,
+        double result[])
     {
-        float r[] = validate(result, 4);
+        double r[] = validate(result, 4);
 
-        float q0x = q0[0];
-        float q0y = q0[1];
-        float q0z = q0[2];
-        float q0w = q0[3];
-        float q1x = q1[0];
-        float q1y = q1[1];
-        float q1z = q1[2];
-        float q1w = q1[3];
+        double q0x = q0[0];
+        double q0y = q0[1];
+        double q0z = q0[2];
+        double q0w = q0[3];
+        double q1x = q1[0];
+        double q1y = q1[1];
+        double q1z = q1[2];
+        double q1w = q1[3];
 
         r[0] = q0w * q1x + q0x * q1w + q0y * q1z - q0z * q1y;
         r[1] = q0w * q1y - q0x * q1z + q0y * q1w + q0z * q1x;
@@ -258,14 +258,14 @@ public class VecMath
      * @param result The result
      * @return The result
      */
-    static float[] multiplyMatrix4WithPoint(float matrix4[], float point[],
-        float result[])
+    static double[] multiplyMatrix4WithPoint(double matrix4[], double point[],
+        double result[])
     {
-        float r[] = validate(result, 3);
+        double r[] = validate(result, 3);
 
-        float x = point[0];
-        float y = point[1];
-        float z = point[2];
+        double x = point[0];
+        double y = point[1];
+        double z = point[2];
         r[0] = matrix4[0] * x + matrix4[4] * y + matrix4[8] * z + matrix4[12];
         r[1] = matrix4[1] * x + matrix4[5] * y + matrix4[9] * z + matrix4[13];
         r[2] = matrix4[2] * x + matrix4[6] * y + matrix4[10] * z + matrix4[14];
@@ -286,14 +286,14 @@ public class VecMath
      * @param result The result
      * @return The result
      */
-    static float[] multiplyMatrix4WithVector(float matrix4[], float vector[],
-        float result[])
+    static double[] multiplyMatrix4WithVector(double matrix4[], double vector[],
+        double result[])
     {
-        float r[] = validate(result, 3);
+        double r[] = validate(result, 3);
 
-        float x = vector[0];
-        float y = vector[1];
-        float z = vector[2];
+        double x = vector[0];
+        double y = vector[1];
+        double z = vector[2];
         r[0] = matrix4[0] * x + matrix4[4] * y + matrix4[8] * z;
         r[1] = matrix4[1] * x + matrix4[5] * y + matrix4[9] * z;
         r[2] = matrix4[2] * x + matrix4[6] * y + matrix4[10] * z;
@@ -312,32 +312,32 @@ public class VecMath
      * @param result The result
      * @return The result
      */
-    static float[] createScalarLastQuaternionFromAxisAngleRad(float axis[],
-        float angleRad, float result[])
+    static double[] createScalarLastQuaternionFromAxisAngleRad(double axis[],
+        double angleRad, double result[])
     {
-        float r[] = validate(result, 4);
+        double r[] = validate(result, 4);
 
-        float halfAngleRad = angleRad * 0.5f;
-        float s = (float) Math.sin(halfAngleRad);
+        double halfAngleRad = angleRad * 0.5;
+        double s = Math.sin(halfAngleRad);
 
-        float x = axis[0];
-        float y = axis[1];
-        float z = axis[2];
-        float lenSquared = x * x + y * y + z * z;
+        double x = axis[0];
+        double y = axis[1];
+        double z = axis[2];
+        double lenSquared = x * x + y * y + z * z;
         if (lenSquared < EPSILON)
         {
-            r[0] = 0.0f;
-            r[1] = 0.0f;
-            r[2] = 0.0f;
-            r[3] = 1.0f;
+            r[0] = 0.0;
+            r[1] = 0.0;
+            r[2] = 0.0;
+            r[3] = 1.0;
             return r;
         }
 
-        float invLen = (float) (1.0 / Math.sqrt(lenSquared));
+        double invLen = 1.0 / Math.sqrt(lenSquared);
         r[0] = x * invLen * s;
         r[1] = y * invLen * s;
         r[2] = z * invLen * s;
-        r[3] = (float) Math.cos(halfAngleRad);
+        r[3] = Math.cos(halfAngleRad);
         return r;
     }
 
@@ -352,22 +352,22 @@ public class VecMath
      * @param result The result
      * @return The the result
      */
-    static float[] createAxisAngleRadFromScalarLastQuaternion(float q[],
-        float result[])
+    static double[] createAxisAngleRadFromScalarLastQuaternion(double q[],
+        double result[])
     {
-        float r[] = validate(result, 4);
+        double r[] = validate(result, 4);
 
-        float qx = q[0];
-        float qy = q[1];
-        float qz = q[2];
-        float qw = q[3];
-        float x = 1.0f;
-        float y = 0.0f;
-        float z = 0.0f;
-        float angleRad = 0.0f;
+        double qx = q[0];
+        double qy = q[1];
+        double qz = q[2];
+        double qw = q[3];
+        double x = 1.0;
+        double y = 0.0;
+        double z = 0.0;
+        double angleRad = 0.0;
         if (Math.abs(qw - 1.0) >= EPSILON && Math.abs(qw + 1.0) >= EPSILON)
         {
-            float f = (float) (1.0 / Math.sqrt(1.0 - qw * qw));
+            double f = 1.0 / Math.sqrt(1.0 - qw * qw);
             x = qx * f;
             y = qy * f;
             z = qz * f;
@@ -375,7 +375,7 @@ public class VecMath
         }
         if (Math.abs(qw - 1.0) >= EPSILON)
         {
-            angleRad = (float) (2.0 * Math.acos(qw));
+            angleRad = 2.0 * Math.acos(qw);
         }
         r[0] = x;
         r[1] = y;
@@ -399,30 +399,30 @@ public class VecMath
      * @param result The inverse matrix
      * @return The result
      */
-    static float[] invert4x4(float m[], float result[])
+    static double[] invert4x4(double m[], double result[])
     {
-        float r[] = validate(result, 16);
+        double r[] = validate(result, 16);
 
         // Adapted from The Mesa 3-D graphics library.
         // Copyright (C) 1999-2007 Brian Paul All Rights Reserved.
         // Published under the MIT license (see the header of this file)
         // @formatter:off
-        float m0 = m[ 0];
-        float m1 = m[ 1];
-        float m2 = m[ 2];
-        float m3 = m[ 3];
-        float m4 = m[ 4];
-        float m5 = m[ 5];
-        float m6 = m[ 6];
-        float m7 = m[ 7];
-        float m8 = m[ 8];
-        float m9 = m[ 9];
-        float mA = m[10];
-        float mB = m[11];
-        float mC = m[12];
-        float mD = m[13];
-        float mE = m[14];
-        float mF = m[15];
+        double m0 = m[ 0];
+        double m1 = m[ 1];
+        double m2 = m[ 2];
+        double m3 = m[ 3];
+        double m4 = m[ 4];
+        double m5 = m[ 5];
+        double m6 = m[ 6];
+        double m7 = m[ 7];
+        double m8 = m[ 8];
+        double m9 = m[ 9];
+        double mA = m[10];
+        double mB = m[11];
+        double mC = m[12];
+        double mD = m[13];
+        double mE = m[14];
+        double mF = m[15];
 
         r[ 0] =  m5 * mA * mF - m5 * mB * mE - m9 * m6 * mF + 
                  m9 * m7 * mE + mD * m6 * mB - mD * m7 * mA;
@@ -459,13 +459,13 @@ public class VecMath
         // (Ain't that pretty?)
         // @formatter:on
 
-        float det = m0 * r[0] + m1 * r[4] + m2 * r[8] + m3 * r[12];
+        double det = m0 * r[0] + m1 * r[4] + m2 * r[8] + m3 * r[12];
         if (Math.abs(det) <= EPSILON)
         {
             identity4x4(r);
             return r;
         }
-        float invDet = 1.0f / det;
+        double invDet = 1.0 / det;
         for (int i = 0; i < 16; i++)
         {
             r[i] *= invDet;
@@ -487,63 +487,63 @@ public class VecMath
      * @param result The result
      * @return The result
      */
-    public static float[] mul4x4(float a[], float b[], float result[])
+    public static double[] mul4x4(double a[], double b[], double result[])
     {
-        float r[] = validate(result, 16);
+        double r[] = validate(result, 16);
 
-        float a00 = a[0];
-        float a10 = a[1];
-        float a20 = a[2];
-        float a30 = a[3];
-        float a01 = a[4];
-        float a11 = a[5];
-        float a21 = a[6];
-        float a31 = a[7];
-        float a02 = a[8];
-        float a12 = a[9];
-        float a22 = a[10];
-        float a32 = a[11];
-        float a03 = a[12];
-        float a13 = a[13];
-        float a23 = a[14];
-        float a33 = a[15];
+        double a00 = a[0];
+        double a10 = a[1];
+        double a20 = a[2];
+        double a30 = a[3];
+        double a01 = a[4];
+        double a11 = a[5];
+        double a21 = a[6];
+        double a31 = a[7];
+        double a02 = a[8];
+        double a12 = a[9];
+        double a22 = a[10];
+        double a32 = a[11];
+        double a03 = a[12];
+        double a13 = a[13];
+        double a23 = a[14];
+        double a33 = a[15];
 
-        float b00 = b[0];
-        float b10 = b[1];
-        float b20 = b[2];
-        float b30 = b[3];
-        float b01 = b[4];
-        float b11 = b[5];
-        float b21 = b[6];
-        float b31 = b[7];
-        float b02 = b[8];
-        float b12 = b[9];
-        float b22 = b[10];
-        float b32 = b[11];
-        float b03 = b[12];
-        float b13 = b[13];
-        float b23 = b[14];
-        float b33 = b[15];
+        double b00 = b[0];
+        double b10 = b[1];
+        double b20 = b[2];
+        double b30 = b[3];
+        double b01 = b[4];
+        double b11 = b[5];
+        double b21 = b[6];
+        double b31 = b[7];
+        double b02 = b[8];
+        double b12 = b[9];
+        double b22 = b[10];
+        double b32 = b[11];
+        double b03 = b[12];
+        double b13 = b[13];
+        double b23 = b[14];
+        double b33 = b[15];
 
-        float m00 = a00 * b00 + a01 * b10 + a02 * b20 + a03 * b30;
-        float m01 = a00 * b01 + a01 * b11 + a02 * b21 + a03 * b31;
-        float m02 = a00 * b02 + a01 * b12 + a02 * b22 + a03 * b32;
-        float m03 = a00 * b03 + a01 * b13 + a02 * b23 + a03 * b33;
+        double m00 = a00 * b00 + a01 * b10 + a02 * b20 + a03 * b30;
+        double m01 = a00 * b01 + a01 * b11 + a02 * b21 + a03 * b31;
+        double m02 = a00 * b02 + a01 * b12 + a02 * b22 + a03 * b32;
+        double m03 = a00 * b03 + a01 * b13 + a02 * b23 + a03 * b33;
 
-        float m10 = a10 * b00 + a11 * b10 + a12 * b20 + a13 * b30;
-        float m11 = a10 * b01 + a11 * b11 + a12 * b21 + a13 * b31;
-        float m12 = a10 * b02 + a11 * b12 + a12 * b22 + a13 * b32;
-        float m13 = a10 * b03 + a11 * b13 + a12 * b23 + a13 * b33;
+        double m10 = a10 * b00 + a11 * b10 + a12 * b20 + a13 * b30;
+        double m11 = a10 * b01 + a11 * b11 + a12 * b21 + a13 * b31;
+        double m12 = a10 * b02 + a11 * b12 + a12 * b22 + a13 * b32;
+        double m13 = a10 * b03 + a11 * b13 + a12 * b23 + a13 * b33;
 
-        float m20 = a20 * b00 + a21 * b10 + a22 * b20 + a23 * b30;
-        float m21 = a20 * b01 + a21 * b11 + a22 * b21 + a23 * b31;
-        float m22 = a20 * b02 + a21 * b12 + a22 * b22 + a23 * b32;
-        float m23 = a20 * b03 + a21 * b13 + a22 * b23 + a23 * b33;
+        double m20 = a20 * b00 + a21 * b10 + a22 * b20 + a23 * b30;
+        double m21 = a20 * b01 + a21 * b11 + a22 * b21 + a23 * b31;
+        double m22 = a20 * b02 + a21 * b12 + a22 * b22 + a23 * b32;
+        double m23 = a20 * b03 + a21 * b13 + a22 * b23 + a23 * b33;
 
-        float m30 = a30 * b00 + a31 * b10 + a32 * b20 + a33 * b30;
-        float m31 = a30 * b01 + a31 * b11 + a32 * b21 + a33 * b31;
-        float m32 = a30 * b02 + a31 * b12 + a32 * b22 + a33 * b32;
-        float m33 = a30 * b03 + a31 * b13 + a32 * b23 + a33 * b33;
+        double m30 = a30 * b00 + a31 * b10 + a32 * b20 + a33 * b30;
+        double m31 = a30 * b01 + a31 * b11 + a32 * b21 + a33 * b31;
+        double m32 = a30 * b02 + a31 * b12 + a32 * b22 + a33 * b32;
+        double m33 = a30 * b03 + a31 * b13 + a32 * b23 + a33 * b33;
 
         r[0] = m00;
         r[1] = m10;
@@ -577,9 +577,9 @@ public class VecMath
      * @param result The result
      * @return The result
      */
-    static float[] createMatrix4FromMatrix3(float matrix3[], float result[])
+    static double[] createMatrix4FromMatrix3(double matrix3[], double result[])
     {
-        float r[] = validate(result, 16);
+        double r[] = validate(result, 16);
 
         r[0] = matrix3[0];
         r[1] = matrix3[1];
@@ -593,7 +593,7 @@ public class VecMath
         r[9] = matrix3[7];
         r[10] = matrix3[8];
 
-        r[15] = 1.0f;
+        r[15] = 1.0;
 
         return r;
 
@@ -609,15 +609,15 @@ public class VecMath
      * @param result The result
      * @return The result
      */
-    public static float[] identity4x4(float result[])
+    public static double[] identity4x4(double result[])
     {
-        float r[] = validate(result, 16);
+        double r[] = validate(result, 16);
 
-        Arrays.fill(r, 0.0f);
-        r[0] = 1.0f;
-        r[5] = 1.0f;
-        r[10] = 1.0f;
-        r[15] = 1.0f;
+        Arrays.fill(r, 0.0);
+        r[0] = 1.0;
+        r[5] = 1.0;
+        r[10] = 1.0;
+        r[15] = 1.0;
         return r;
     }
 
@@ -638,10 +638,10 @@ public class VecMath
      * @param result The result
      * @return The result
      */
-    public static float[] translate4x4(float m[], float x, float y, float z,
-        float result[])
+    public static double[] translate4x4(double m[], double x, double y, double z,
+        double result[])
     {
-        float r[] = validate(result, 16);
+        double r[] = validate(result, 16);
         set(m, r);
         r[12] += x;
         r[13] += y;
@@ -661,36 +661,36 @@ public class VecMath
      * @param result The result
      * @return The matrix
      */
-    public static float[] rotationX(float angleRad, float result[])
+    public static double[] rotationX(double angleRad, double result[])
     {
-        float matrix[] = validate(result, 16);
+        double matrix[] = validate(result, 16);
 
-        float c = (float) Math.cos(angleRad);
-        float s = (float) Math.sin(angleRad);
+        double c = Math.cos(angleRad);
+        double s = Math.sin(angleRad);
 
         // Column 0
-        matrix[0] = 1.0f;
-        matrix[1] = 0.0f;
-        matrix[2] = 0.0f;
-        matrix[3] = 0.0f;
+        matrix[0] = 1.0;
+        matrix[1] = 0.0;
+        matrix[2] = 0.0;
+        matrix[3] = 0.0;
 
         // Column 1
-        matrix[4] = 0.0f;
+        matrix[4] = 0.0;
         matrix[5] = c;
         matrix[6] = s;
-        matrix[7] = 0.0f;
+        matrix[7] = 0.0;
 
         // Column 2
-        matrix[8] = 0.0f;
+        matrix[8] = 0.0;
         matrix[9] = -s;
         matrix[10] = c;
-        matrix[11] = 0.0f;
+        matrix[11] = 0.0;
 
         // Column 3
-        matrix[12] = 0.0f;
-        matrix[13] = 0.0f;
-        matrix[14] = 0.0f;
-        matrix[15] = 1.0f;
+        matrix[12] = 0.0;
+        matrix[13] = 0.0;
+        matrix[14] = 0.0;
+        matrix[15] = 1.0;
 
         return matrix;
     }
@@ -705,36 +705,36 @@ public class VecMath
      * @param result The result
      * @return The matrix
      */
-    public static float[] rotationY(float angleRad, float result[])
+    public static double[] rotationY(double angleRad, double result[])
     {
-        float matrix[] = validate(result, 16);
+        double matrix[] = validate(result, 16);
 
-        float c = (float) Math.cos(angleRad);
-        float s = (float) Math.sin(angleRad);
+        double c = Math.cos(angleRad);
+        double s = Math.sin(angleRad);
 
         // Column 0
         matrix[0] = c;
-        matrix[1] = 0.0f;
+        matrix[1] = 0.0;
         matrix[2] = -s;
-        matrix[3] = 0.0f;
+        matrix[3] = 0.0;
 
         // Column 1
-        matrix[4] = 0.0f;
-        matrix[5] = 1.0f;
-        matrix[6] = 0.0f;
-        matrix[7] = 0.0f;
+        matrix[4] = 0.0;
+        matrix[5] = 1.0;
+        matrix[6] = 0.0;
+        matrix[7] = 0.0;
 
         // Column 2
         matrix[8] = s;
-        matrix[9] = 0.0f;
+        matrix[9] = 0.0;
         matrix[10] = c;
-        matrix[11] = 0.0f;
+        matrix[11] = 0.0;
 
         // Column 3
-        matrix[12] = 0.0f;
-        matrix[13] = 0.0f;
-        matrix[14] = 0.0f;
-        matrix[15] = 1.0f;
+        matrix[12] = 0.0;
+        matrix[13] = 0.0;
+        matrix[14] = 0.0;
+        matrix[15] = 1.0;
 
         return matrix;
     }
@@ -750,36 +750,36 @@ public class VecMath
      * @param result The result
      * @return The matrix
      */
-    public static float[] rotationZ(float angleRad, float result[])
+    public static double[] rotationZ(double angleRad, double result[])
     {
-        float matrix[] = validate(result, 16);
+        double matrix[] = validate(result, 16);
 
-        float c = (float) Math.cos(angleRad);
-        float s = (float) Math.sin(angleRad);
+        double c = Math.cos(angleRad);
+        double s = Math.sin(angleRad);
 
         // Column 0
         matrix[0] = c;
         matrix[1] = s;
-        matrix[2] = 0.0f;
-        matrix[3] = 0.0f;
+        matrix[2] = 0.0;
+        matrix[3] = 0.0;
 
         // Column 1
         matrix[4] = -s;
         matrix[5] = c;
-        matrix[6] = 0.0f;
-        matrix[7] = 0.0f;
+        matrix[6] = 0.0;
+        matrix[7] = 0.0;
 
         // Column 2
-        matrix[8] = 0.0f;
-        matrix[9] = 0.0f;
-        matrix[10] = 1.0f;
-        matrix[11] = 0.0f;
+        matrix[8] = 0.0;
+        matrix[9] = 0.0;
+        matrix[10] = 1.0;
+        matrix[11] = 0.0;
 
         // Column 3
-        matrix[12] = 0.0f;
-        matrix[13] = 0.0f;
-        matrix[14] = 0.0f;
-        matrix[15] = 1.0f;
+        matrix[12] = 0.0;
+        matrix[13] = 0.0;
+        matrix[14] = 0.0;
+        matrix[15] = 1.0;
 
         return matrix;
     }
@@ -794,13 +794,13 @@ public class VecMath
      * @param result The result 
      * @return The result
      */
-    public static float[] scale4x4(float s, float result[])
+    public static double[] scale4x4(double s, double result[])
     {
-        float[] r = identity4x4(result);
+        double[] r = identity4x4(result);
         r[0] = s;
         r[5] = s;
         r[10] = s;
-        r[15] = 1.0f;
+        r[15] = 1.0;
         return r;
     }
     
@@ -816,13 +816,13 @@ public class VecMath
      * @param result The result 
      * @return The result
      */
-    public static float[] scale4x4(float sx, float sy, float sz, float result[])
+    public static double[] scale4x4(double sx, double sy, double sz, double result[])
     {
-        float[] r = identity4x4(result);
+        double[] r = identity4x4(result);
         r[0] = sx;
         r[5] = sy;
         r[10] = sz;
-        r[15] = 1.0f;
+        r[15] = 1.0;
         return r;
     }
     
@@ -833,7 +833,7 @@ public class VecMath
      * @param source The source array
      * @param target The target array
      */
-    private static void set(float source[], float target[])
+    private static void set(double source[], double target[])
     {
         System.arraycopy(source, 0, target, 0,
             Math.min(source.length, target.length));
@@ -848,15 +848,15 @@ public class VecMath
      * @param length The length
      * @return The result
      */
-    private static float[] validate(float array[], int length)
+    private static double[] validate(double array[], int length)
     {
         if (array == null)
         {
-            return new float[length];
+            return new double[length];
         }
         if (array.length != length)
         {
-            return new float[length];
+            return new double[length];
         }
         return array;
     }

--- a/jsplat-processing/src/test/java/de/javagl/jsplat/processing/SplatTransformsTest.java
+++ b/jsplat-processing/src/test/java/de/javagl/jsplat/processing/SplatTransformsTest.java
@@ -46,7 +46,7 @@ public class SplatTransformsTest
     /**
      * The epsilon for comparisons
      */
-    private static final float EPSILON = 1e-5f;
+    private static final double EPSILON = 1e-5f;
 
     /**
      * Test whether a random splat remains unmodified under identity transform
@@ -58,7 +58,7 @@ public class SplatTransformsTest
         MutableSplat splat = createRandomSplat(3, random);
         MutableSplat expectedSplat = Splats.copy(splat);
 
-        float[] identityMatrix = VecMath.identity4x4(null);
+        double[] identityMatrix = VecMath.identity4x4(null);
 
         SplatTransforms.transformList(Arrays.asList(splat), identityMatrix);
 
@@ -105,8 +105,8 @@ public class SplatTransformsTest
             MutableSplat splat = createRandomSplat(shDegree, random);
             MutableSplat expectedSplat = Splats.copy(splat);
 
-            float[] m = TestUtils.createRandomMatrix4(random);
-            float[] inv = VecMath.invert4x4(m, null);
+            double[] m = TestUtils.createRandomMatrix4(random);
+            double[] inv = VecMath.invert4x4(m, null);
 
             SplatTransforms.transformList(Arrays.asList(splat), m);
             SplatTransforms.transformList(Arrays.asList(splat), inv);
@@ -127,25 +127,25 @@ public class SplatTransformsTest
     {
         MutableSplat splat = Splats.create(shDegree);
 
-        splat.setPositionX(random.nextFloat() * 20.0f - 10.0f);
-        splat.setPositionY(random.nextFloat() * 20.0f - 10.0f);
-        splat.setPositionZ(random.nextFloat() * 20.0f - 10.0f);
+        splat.setPositionX(random.nextDouble() * 20.0 - 10.0);
+        splat.setPositionY(random.nextDouble() * 20.0 - 10.0);
+        splat.setPositionZ(random.nextDouble() * 20.0 - 10.0);
 
-        float[] q = TestUtils.createRandomScalarLastQuaternion(random);
+        double[] q = TestUtils.createRandomScalarLastQuaternion(random);
         splat.setRotationX(q[0]);
         splat.setRotationY(q[1]);
         splat.setRotationZ(q[2]);
         splat.setRotationW(q[3]);
 
-        splat.setScaleX(-1.0f + random.nextFloat() * 2.0f);
-        splat.setScaleY(-1.0f + random.nextFloat() * 2.0f);
-        splat.setScaleZ(-1.0f + random.nextFloat() * 2.0f);
+        splat.setScaleX(-1.0f + random.nextDouble() * 2.0);
+        splat.setScaleY(-1.0f + random.nextDouble() * 2.0);
+        splat.setScaleZ(-1.0f + random.nextDouble() * 2.0);
 
         for (int i = 0; i < splat.getShDimensions(); i++)
         {
-            splat.setShX(i, -1.0f + random.nextFloat() * 2.0f);
-            splat.setShY(i, -1.0f + random.nextFloat() * 2.0f);
-            splat.setShZ(i, -1.0f + random.nextFloat() * 2.0f);
+            splat.setShX(i, -1.0f + random.nextDouble() * 2.0);
+            splat.setShY(i, -1.0f + random.nextDouble() * 2.0);
+            splat.setShZ(i, -1.0f + random.nextDouble() * 2.0);
         }
         return splat;
     }
@@ -174,15 +174,15 @@ public class SplatTransformsTest
         assertEquals(message + ": ScaleZ", expected.getScaleZ(),
             actual.getScaleZ(), EPSILON);
 
-        float ax = actual.getRotationX();
-        float ay = actual.getRotationY();
-        float az = actual.getRotationZ();
-        float aw = actual.getRotationW();
+        double ax = actual.getRotationX();
+        double ay = actual.getRotationY();
+        double az = actual.getRotationZ();
+        double aw = actual.getRotationW();
 
-        float bx = expected.getRotationX();
-        float by = expected.getRotationY();
-        float bz = expected.getRotationZ();
-        float bw = expected.getRotationW();
+        double bx = expected.getRotationX();
+        double by = expected.getRotationY();
+        double bz = expected.getRotationZ();
+        double bw = expected.getRotationW();
 
         boolean rotationEqual =
             TestUtils.rotationEqual(ax, ay, az, aw, bx, by, bz, bw, EPSILON);

--- a/jsplat-processing/src/test/java/de/javagl/jsplat/processing/TestUtils.java
+++ b/jsplat-processing/src/test/java/de/javagl/jsplat/processing/TestUtils.java
@@ -39,14 +39,14 @@ public class TestUtils
      * @param random The random number generator
      * @return The matrix
      */
-    static float[] createRandomMatrix4(Random random)
+    static double[] createRandomMatrix4(Random random)
     {
-        float[] q = createRandomScalarLastQuaternion(random);
-        float[] m3 = VecMath.scalarLastQuaternionToRotationMatrix(q, null);
-        float[] m4 = VecMath.createMatrix4FromMatrix3(m3, null);
-        float tx = -10.0f + random.nextFloat() * 20.0f;
-        float ty = -10.0f + random.nextFloat() * 20.0f;
-        float tz = -10.0f + random.nextFloat() * 20.0f;
+        double[] q = createRandomScalarLastQuaternion(random);
+        double[] m3 = VecMath.scalarLastQuaternionToRotationMatrix(q, null);
+        double[] m4 = VecMath.createMatrix4FromMatrix3(m3, null);
+        double tx = -10.0 + random.nextDouble() * 20.0;
+        double ty = -10.0 + random.nextDouble() * 20.0;
+        double tz = -10.0 + random.nextDouble() * 20.0;
         VecMath.translate4x4(m4, tx, ty, tz, m4);
         return m4;
     }
@@ -57,14 +57,14 @@ public class TestUtils
      * @param random The random number generator
      * @return The quaternion
      */
-    static float[] createRandomScalarLastQuaternion(Random random)
+    static double[] createRandomScalarLastQuaternion(Random random)
     {
-        float axis[] = new float[3];
-        axis[0] = -1.0f + random.nextFloat() * 2.0f;
-        axis[1] = -1.0f + random.nextFloat() * 2.0f;
-        axis[2] = -1.0f + random.nextFloat() * 2.0f;
-        float angleRad = random.nextFloat() * (float) (Math.PI * 2.0);
-        float q[] = VecMath.createScalarLastQuaternionFromAxisAngleRad(axis,
+        double axis[] = new double[3];
+        axis[0] = -1.0 + random.nextDouble() * 2.0;
+        axis[1] = -1.0 + random.nextDouble() * 2.0;
+        axis[2] = -1.0 + random.nextDouble() * 2.0;
+        double angleRad = random.nextDouble() * (Math.PI * 2.0);
+        double q[] = VecMath.createScalarLastQuaternionFromAxisAngleRad(axis,
             angleRad, null);
         return q;
     }
@@ -89,25 +89,25 @@ public class TestUtils
      * @param epsilon The epsilon
      * @return The result
      */
-    static boolean rotationEqual(float ax, float ay, float az, float aw,
-        float bx, float by, float bz, float bw, float epsilon)
+    static boolean rotationEqual(double ax, double ay, double az, double aw,
+        double bx, double by, double bz, double bw, double epsilon)
     {
-        float aLenSquared = ax * ax + ay * ay + az * az + aw * aw;
-        float aInvLen = 1.0f / (float) Math.sqrt(aLenSquared);
-        float anx = ax * aInvLen;
-        float any = ay * aInvLen;
-        float anz = az * aInvLen;
-        float anw = aw * aInvLen;
+        double aLenSquared = ax * ax + ay * ay + az * az + aw * aw;
+        double aInvLen = 1.0f / Math.sqrt(aLenSquared);
+        double anx = ax * aInvLen;
+        double any = ay * aInvLen;
+        double anz = az * aInvLen;
+        double anw = aw * aInvLen;
 
-        float bLenSquared = bx * bx + by * by + bz * bz + bw * bw;
-        float bInvLen = 1.0f / (float) Math.sqrt(bLenSquared);
-        float bnx = bx * bInvLen;
-        float bny = by * bInvLen;
-        float bnz = bz * bInvLen;
-        float bnw = bw * bInvLen;
+        double bLenSquared = bx * bx + by * by + bz * bz + bw * bw;
+        double bInvLen = 1.0f / Math.sqrt(bLenSquared);
+        double bnx = bx * bInvLen;
+        double bny = by * bInvLen;
+        double bnz = bz * bInvLen;
+        double bnw = bw * bInvLen;
 
-        float dot = anx * bnx + any * bny + anz * bnz + anw * bnw;
-        boolean rotationEqual = Math.abs(Math.abs(dot) - 1.0f) <= epsilon;
+        double dot = anx * bnx + any * bny + anz * bnz + anw * bnw;
+        boolean rotationEqual = Math.abs(Math.abs(dot) - 1.0) <= epsilon;
         return rotationEqual;
     }
 

--- a/jsplat-processing/src/test/java/de/javagl/jsplat/processing/VecMathTest.java
+++ b/jsplat-processing/src/test/java/de/javagl/jsplat/processing/VecMathTest.java
@@ -41,7 +41,7 @@ public class VecMathTest
     /**
      * The epsilon for comparisons
      */
-    private static final float EPSILON = 1e-5f;
+    private static final double EPSILON = 1e-5;
 
     /**
      * Basic test for matrix-quaternion conversions
@@ -52,9 +52,9 @@ public class VecMathTest
         Random random = new Random(0);
         for (int i = 0; i < 100; i++)
         {
-            float[] e = TestUtils.createRandomScalarLastQuaternion(random);
-            float[] m = VecMath.scalarLastQuaternionToRotationMatrix(e, null);
-            float[] a = VecMath.rotationMatrixToScalarLastQuaternion(m, null);
+            double[] e = TestUtils.createRandomScalarLastQuaternion(random);
+            double[] m = VecMath.scalarLastQuaternionToRotationMatrix(e, null);
+            double[] a = VecMath.rotationMatrixToScalarLastQuaternion(m, null);
 
             String message =
                 "\n a=" + Arrays.toString(a) + ",\n e=" + Arrays.toString(e);

--- a/jsplat-simplification/NanoGS-LICENSE.txt
+++ b/jsplat-simplification/NanoGS-LICENSE.txt
@@ -1,0 +1,417 @@
+
+The classes in the `de.javagl.jsplat.simplification.incremental.nanogs` 
+package have been ported from https://github.com/saliteta/NanoGS 
+Commit: 62ddc34e230a01c061b762103ef69113f6259e48.
+
+Original license text:
+
+=======================================================================
+
+
+Attribution-NonCommercial 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution-NonCommercial 4.0 International Public
+License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-NonCommercial 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. NonCommercial means not primarily intended for or directed towards
+     commercial advantage or monetary compensation. For purposes of
+     this Public License, the exchange of the Licensed Material for
+     other material subject to Copyright and Similar Rights by digital
+     file-sharing or similar means is NonCommercial provided there is
+     no payment of monetary compensation in connection with the
+     exchange.
+
+  j. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  k. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  l. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part, for NonCommercial purposes only; and
+
+            b. produce, reproduce, and Share Adapted Material for
+               NonCommercial purposes only.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties, including when
+          the Licensed Material is used other than for NonCommercial
+          purposes.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database for NonCommercial purposes
+     only;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/jsplat-simplification/README.md
+++ b/jsplat-simplification/README.md
@@ -1,0 +1,25 @@
+# jsplat-simplification
+
+Experimental classes for simplifying Gaussian splats.
+
+---
+
+The classes in the `de.javagl.jsplat.simplification.incremental.nanogs` 
+package have been ported from https://github.com/saliteta/NanoGS 
+Commit: 62ddc34e230a01c061b762103ef69113f6259e48.
+
+This package is therefore published under "Attribution-NonCommercial 4.0 International" 
+license. See the "NanoGS-LICENSE.txt" for details.
+
+Citation:
+```
+@misc{xiong2026nanogstrainingfreegaussiansplat,
+    title={NanoGS: Training-Free Gaussian Splat Simplification}, 
+    author={Butian Xiong and Rong Liu and Tiantian Zhou and Meida Chen and Zhiwen Fan and Andrew Feng},
+    year={2026},
+    eprint={2603.16103},
+    archivePrefix={arXiv},
+    primaryClass={cs.CV},
+    url={https://arxiv.org/abs/2603.16103}, 
+}
+```

--- a/jsplat-simplification/pom.xml
+++ b/jsplat-simplification/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>jsplat-simplification</artifactId>
+
+	<name>${project.groupId}:${project.artifactId}</name>
+	<description>A splat library for Java</description>
+	<url>https://github.com/javagl/JSplat</url>
+
+	<parent>
+		<groupId>de.javagl</groupId>
+		<artifactId>jsplat-parent</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>de.javagl</groupId>
+			<artifactId>jsplat</artifactId>
+			<version>0.0.1-SNAPSHOT</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>io.github.elki-project</groupId>
+			<artifactId>elki</artifactId>
+			<version>0.8.0</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/Simplifier.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/Simplifier.java
@@ -1,0 +1,47 @@
+/*
+ * www.javagl.de - JSplat
+ *
+ * Copyright 2026 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jsplat.simplification;
+
+import java.util.List;
+
+import de.javagl.jsplat.Splat;
+
+/**
+ * Interface for classes that can simplify a list of splats
+ */
+public interface Simplifier
+{
+    /**
+     * Simplify the given list of splats
+     * 
+     * @param splats The splats
+     * @param ratio The simplification ratio, i.e. the ratio of the splats
+     * that should be kept, in [0, 1]
+     * @return The simplified splats
+     */
+    List<Splat> simplify(List<? extends Splat> splats, float ratio);
+}

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/Simplifiers.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/Simplifiers.java
@@ -1,0 +1,57 @@
+/*
+ * www.javagl.de - JSplat
+ *
+ * Copyright 2026 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jsplat.simplification;
+
+import de.javagl.jsplat.simplification.incremental.nanogs.NanoGs;
+
+/**
+ * Methods related to {@link Simplifier} instances
+ */
+public class Simplifiers
+{
+    /**
+     * Create a NanoGS simplifier with all default values
+     * 
+     * @return The {@link Simplifier}
+     */
+    public static Simplifier createNanoGs()
+    {
+        return (splats, ratio) ->
+        {
+            return NanoGs.simplify(splats, ratio);
+        };
+    }
+
+    /**
+     * Private constructor to prevent instantiation
+     */
+    private Simplifiers()
+    {
+        // Private constructor to prevent instantiation
+    }
+
+}

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/Edge.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/Edge.java
@@ -1,0 +1,62 @@
+/*
+ * www.javagl.de - JSplat
+ *
+ * Copyright 2026 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jsplat.simplification.incremental;
+
+/**
+ * A weighted edge between two indexed elements.
+ * 
+ * This class is not part of any public API.
+ */
+public class Edge
+{
+    /**
+     * The first index
+     */
+    public final int i0;
+
+    /**
+     * The second index
+     */
+    public final int i1;
+
+    /**
+     * The weight
+     */
+    public float weight;
+
+    /**
+     * Creates a new instance
+     * 
+     * @param i0 The first index
+     * @param i1 The second index
+     */
+    Edge(int i0, int i1)
+    {
+        this.i0 = i0;
+        this.i1 = i1;
+    }
+}

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/Edge.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/Edge.java
@@ -46,7 +46,7 @@ public class Edge
     /**
      * The weight
      */
-    public float weight;
+    public double weight;
 
     /**
      * Creates a new instance

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/Edges.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/Edges.java
@@ -1,0 +1,103 @@
+/*
+ * www.javagl.de - JSplat
+ *
+ * Copyright 2026 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jsplat.simplification.incremental;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import de.javagl.jsplat.Splat;
+
+/**
+ * Computation of edges between splats and their nearest neighbors
+ */
+public class Edges
+{
+
+    /**
+     * Computes edges between each of the given splats and its k nearest
+     * neighbors
+     * 
+     * @param splats The splats
+     * @param k The k
+     * @return The edges
+     */
+    public static List<Edge> compute(List<? extends Splat> splats, int k)
+    {
+        double[][] positions = extractPositions(splats);
+        KNN knn = KNNs.create(positions);
+        int n = positions.length;
+        List<Edge> edges = IntStream.range(0, n).parallel().mapToObj(i0 ->
+        {
+            List<Edge> innerEdges = new ArrayList<Edge>(k);
+            double[] query = positions[i0];
+            List<Integer> knnIndices = knn.compute(query, k + 1);
+            for (int j = 1; j < knnIndices.size(); j++)
+            {
+                int i1 = knnIndices.get(j);
+                Edge edge = new Edge(i0, i1);
+                innerEdges.add(edge);
+            }
+            return innerEdges;
+        }).flatMap(e -> e.stream()).collect(Collectors.toList());
+        return edges;
+    }
+
+    /**
+     * Extract the positions from the given splats, as an array of 3-element
+     * arrays
+     * 
+     * @param splats The splats
+     * @return The positions
+     */
+    private static double[][] extractPositions(List<? extends Splat> splats)
+    {
+        int n = splats.size();
+        double result[][] = new double[n][];
+        IntStream.range(0, n).parallel().forEach(i ->
+        {
+            Splat s = splats.get(i);
+            double x = s.getPositionX();
+            double y = s.getPositionY();
+            double z = s.getPositionZ();
+            double p[] =
+            { x, y, z };
+            result[i] = p;
+        });
+        return result;
+    }
+
+    /**
+     * Private constructor to prevent instantiation
+     */
+    private Edges()
+    {
+        // Private constructor to prevent instantiation
+    }
+
+}

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/KNN.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/KNN.java
@@ -1,0 +1,46 @@
+/*
+ * www.javagl.de - JSplat
+ *
+ * Copyright 2026 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jsplat.simplification.incremental;
+
+import java.util.List;
+
+/**
+ * Internal Interface for something that can compute the indices of the k
+ * nearest elements to a given query point
+ */
+interface KNN
+{
+    /**
+     * Compute the indices of the elements that are nearest to the given query
+     * point
+     * 
+     * @param query The query point
+     * @param k The k
+     * @return The result
+     */
+    List<Integer> compute(double query[], int k);
+}

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/KNNElki.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/KNNElki.java
@@ -1,0 +1,122 @@
+/*
+ * www.javagl.de - JSplat
+ *
+ * Copyright 2026 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jsplat.simplification.incremental;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import elki.data.DoubleVector;
+import elki.data.NumberVector;
+import elki.data.type.TypeUtil;
+import elki.database.Database;
+import elki.database.StaticArrayDatabase;
+import elki.database.ids.DBIDRange;
+import elki.database.ids.DBIDRef;
+import elki.database.ids.KNNList;
+import elki.database.query.distance.DistanceQuery;
+import elki.database.query.knn.KNNSearcher;
+import elki.database.relation.Relation;
+import elki.datasource.ArrayAdapterDatabaseConnection;
+import elki.datasource.DatabaseConnection;
+import elki.distance.minkowski.EuclideanDistance;
+import elki.index.KNNIndex;
+import elki.index.tree.spatial.kd.MinimalisticMemoryKDTree;
+
+/**
+ * Internal implementation of {@link KNN} functionality, using ELKI
+ */
+class KNNElki implements KNN
+{
+    /**
+     * The database ID range
+     */
+    private final DBIDRange dbIds;
+
+    /**
+     * The KNN index
+     */
+    private final KNNIndex<NumberVector> knnIndex;
+
+    /**
+     * The distance query
+     */
+    private final DistanceQuery<NumberVector> distanceQuery;
+
+    /**
+     * Creates a new instance
+     * 
+     * @param data The data
+     */
+    KNNElki(double data[][])
+    {
+        // Create an ELKI database from the data.
+        int startId = 0;
+        DatabaseConnection dbc =
+            new ArrayAdapterDatabaseConnection(data, null, startId);
+        Database d = new StaticArrayDatabase(dbc, null);
+        d.initialize();
+
+        // Obtain the one and only relation and its ID range
+        Relation<NumberVector> relation =
+            d.getRelation(TypeUtil.NUMBER_VECTOR_FIELD);
+        this.dbIds = (DBIDRange) relation.getDBIDs();
+
+        // Crate the KD tree for the spatial query
+        MinimalisticMemoryKDTree.Factory<NumberVector> indexFactory =
+            new MinimalisticMemoryKDTree.Factory<>();
+        this.knnIndex = indexFactory.instantiate(relation);
+        this.knnIndex.initialize();
+        this.distanceQuery = EuclideanDistance.STATIC.instantiate(relation);
+    }
+
+    @Override
+    public List<Integer> compute(double query[], int k)
+    {
+        // Prepare the actual query
+        KNNSearcher<NumberVector> knnSearcher =
+            knnIndex.kNNByObject(distanceQuery, k, 0);
+        NumberVector queryPoint = new DoubleVector(query);
+
+        // Do it!
+        KNNList knn = knnSearcher.getKNN(queryPoint, k);
+
+        // Extract the indices from the KNN result
+        List<Integer> resultIndices = new ArrayList<Integer>();
+        Consumer<DBIDRef> consumer = new Consumer<DBIDRef>()
+        {
+            @Override
+            public void accept(DBIDRef t)
+            {
+                int index = dbIds.getOffset(t);
+                resultIndices.add(index);
+            }
+        };
+        knn.forEach(consumer);
+        return resultIndices;
+    }
+}

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/KNNs.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/KNNs.java
@@ -1,0 +1,68 @@
+/*
+ * www.javagl.de - JSplat
+ *
+ * Copyright 2026 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jsplat.simplification.incremental;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Utilities for computing KNN, k nearest neighbors
+ */
+class KNNs
+{
+    /**
+     * Create a KNN object for the given data
+     * 
+     * @param data The data
+     * @return The result
+     */
+    static KNN create(double data[][])
+    {
+        hackyWorkaroundForElkiLogging();
+        return new KNNElki(data);
+    }
+
+    /**
+     * Whatever they did there, it was wrong...
+     */
+    private static void hackyWorkaroundForElkiLogging()
+    {
+        System.setProperty("java.util.logging.config.file",
+            "ElkiIsMessingWithLogging");
+        Logger logger = Logger.getLogger("elki");
+        logger.setLevel(Level.OFF);
+    }
+    
+    /**
+     * Private constructor to prevent instantiation
+     */
+    private KNNs()
+    {
+        // Private constructor to prevent instantiation
+    }
+
+}

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/Pairs.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/Pairs.java
@@ -1,0 +1,109 @@
+/*
+ * www.javagl.de - JSplat
+ *
+ * Copyright 2026 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jsplat.simplification.incremental;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Methods for computing pairs of elements from edges
+ */
+public class Pairs
+{
+    /**
+     * Selects up to the specified number of edges from the given list, ordered
+     * by their weight, in incresing order
+     * 
+     * @param edges The edges
+     * @param numElements The number of elements that the edge indices refer to
+     * @param numPairsToSelect The maximum number of pairs to select
+     * @return The pairs
+     */
+    public static List<Edge> select(List<Edge> edges, int numElements,
+        int numPairsToSelect)
+    {
+        if (edges.isEmpty())
+        {
+            return Collections.emptyList();
+        }
+        Edge valid[] = new Edge[edges.size()];
+        int counter = 0;
+        for (Edge edge : edges)
+        {
+            if (Float.isFinite(edge.weight))
+            {
+                valid[counter] = edge;
+                counter++;
+            }
+        }
+        if (counter == 0)
+        {
+            return Collections.emptyList();
+        }
+        Arrays.parallelSort(valid, 0, counter, (e0, e1) ->
+        {
+            if (e0.weight < e1.weight)
+            {
+                return -1;
+            }
+            if (e0.weight > e1.weight)
+            {
+                return 1;
+            }
+            return 0;
+        });
+
+        boolean used[] = new boolean[numElements];
+        List<Edge> pairs = new ArrayList<Edge>(numPairsToSelect);
+        for (int i = 0; i < counter; i++)
+        {
+            Edge e = valid[i];
+            if (used[e.i0] || used[e.i1])
+            {
+                continue;
+            }
+            used[e.i0] = true;
+            used[e.i1] = true;
+            pairs.add(e);
+            if (pairs.size() >= numPairsToSelect)
+            {
+                break;
+            }
+        }
+        return pairs;
+    }
+
+    /**
+     * Private constructor to prevent instantiation
+     */
+    private Pairs()
+    {
+        // Private constructor to prevent instantiation
+    }
+}

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/Pairs.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/Pairs.java
@@ -56,7 +56,7 @@ public class Pairs
         int counter = 0;
         for (Edge edge : edges)
         {
-            if (Float.isFinite(edge.weight))
+            if (Double.isFinite(edge.weight))
             {
                 valid[counter] = edge;
                 counter++;

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGs.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGs.java
@@ -1,0 +1,164 @@
+/*
+ * www.javagl.de - JSplat
+ *
+ * Copyright 2026 Marco Hutter - http://www.javagl.de
+ * 
+ * Ported from https://github.com/saliteta/NanoGS
+ * Commit: 62ddc34e230a01c061b762103ef69113f6259e48
+ *
+ * Published under "Attribution-NonCommercial 4.0 International" license.
+ * See the "NanoGS-LICENSE.txt" in the root directory of this project.
+ */
+package de.javagl.jsplat.simplification.incremental.nanogs;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import de.javagl.jsplat.Splat;
+import de.javagl.jsplat.simplification.incremental.Edge;
+import de.javagl.jsplat.simplification.incremental.Edges;
+import de.javagl.jsplat.simplification.incremental.Pairs;
+
+/**
+ * The entry point of the NanoGS simplification.
+ * 
+ * Ported from https://github.com/saliteta/NanoGS 
+ * Commit: 62ddc34e230a01c061b762103ef69113f6259e48
+ * 
+ * This class is not part of the public API.
+ */
+public class NanoGs
+{
+    /**
+     * The logger used in this class
+     */
+    private static final Logger logger =
+        Logger.getLogger(NanoGs.class.getName());
+
+    /**
+     * The log level
+     */
+    private static final Level level = Level.FINE;
+
+    /**
+     * Simplify the given list of splats
+     * 
+     * @param splats The splats
+     * @param ratio The reduction ratio, in [0,1]
+     * @return The result
+     */
+    public static List<Splat> simplify(List<? extends Splat> splats,
+        float ratio)
+    {
+        // All fixed parameters for now
+        float threshold = 0.1f;
+        int k = 16;
+        int nMc = 1;
+        int seed = 0;
+        float epsCov = 1e-8f;
+        float lamGeo = 1.0f;
+        float lamSh = 1.0f;
+        float pCapRatio = 0.5f;
+        
+        logger.log(level, "Simplify " + splats.size() + " with ratio " + ratio);
+        long beforeNs = System.nanoTime();
+
+        List<Splat> cur = Collections.unmodifiableList(splats);
+        int N0 = splats.size();
+        int target = (int) Math.max(Math.ceil(N0 * ratio), 1);
+
+        List<Splat> pruneCur = cur;
+        cur = timed("Pruning",
+            () -> NanoGsPruning.pruneByOpacity(pruneCur, threshold));
+        logger.log(level, "Pruning: " + cur.size() + " splats left");
+
+        float[][] Z = NanoGsSampling.makeGaussianSamples(nMc, seed);
+
+        int iteration = 0;
+        while (cur.size() > target)
+        {
+            int N = cur.size();
+            logger.log(level, "Iteration " + iteration + ": " + N + " splats");
+
+            int kEff = Math.min(Math.max(1, k), Math.max(1, N - 1));
+            List<Splat> edgesCur = cur;
+            List<Edge> edges =
+                timed("  Computing edges", () -> Edges.compute(edgesCur, kEff));
+            logger.log(level,
+                "  Computing edges: " + edges.size() + " edges computed");
+
+            if (edges.isEmpty())
+            {
+                logger.log(level, "  No more edges. Stopping");
+                break;
+            }
+
+            List<Splat> weightsCur = cur;
+            timed("  Computing weights", () ->
+            {
+                NanoGsCost.computeWeights(weightsCur, edges, Z, epsCov, lamGeo,
+                    lamSh);
+                return null;
+            });
+
+            int mergesNeeded = N - target;
+            int pCap = (int) Math.max(1, Math.floor(pCapRatio * N0));
+            int P = mergesNeeded > 0 ? Math.min(mergesNeeded, pCap) : null;
+
+            List<Edge> pairs =
+                timed("  Computing pairs", () -> Pairs.select(edges, N, P));
+            logger.log(level,
+                "  Computing pairs: " + pairs.size() + " pairs computed");
+
+            if (pairs.isEmpty())
+            {
+                logger.log(level, "  No more pairs. Stopping");
+                break;
+            }
+
+            List<Splat> mergeCur = cur;
+            cur = timed("  Computing merged splats",
+                () -> NanoGsMerge.mergePairs(mergeCur, pairs));
+
+            iteration++;
+        }
+
+        long afterNs = System.nanoTime();
+        logger.log(level,
+            "Simplify " + splats.size() + " with ratio " + ratio + " DONE");
+        logger.log(level, "Remaining splats: " + cur.size());
+        logger.log(level, "Duration: " + ((afterNs - beforeNs) / 1e6) + " ms");
+
+        return cur;
+    }
+
+    /**
+     * Run the given supplier, measuring and printing execution time
+     * 
+     * @param <T> The return type
+     * @param name The name of the task
+     * @param supplier The supplier
+     * @return The result
+     */
+    private static <T> T timed(String name, Supplier<? extends T> supplier)
+    {
+        logger.log(level, name + "...");
+        long ns0 = System.nanoTime();
+        T result = supplier.get();
+        long ns1 = System.nanoTime();
+        logger.log(level, name + " DONE, " + ((ns1 - ns0) / 1e6) + "ms");
+        return result;
+    }
+
+    /**
+     * Private constructor to prevent instantiation
+     */
+    private NanoGs()
+    {
+        // Private constructor to prevent instantiation
+    }
+
+}

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGs.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGs.java
@@ -51,17 +51,17 @@ public class NanoGs
      * @return The result
      */
     public static List<Splat> simplify(List<? extends Splat> splats,
-        float ratio)
+        double ratio)
     {
         // All fixed parameters for now
-        float threshold = 0.1f;
+        double threshold = 0.1f;
         int k = 16;
         int nMc = 1;
         int seed = 0;
-        float epsCov = 1e-8f;
-        float lamGeo = 1.0f;
-        float lamSh = 1.0f;
-        float pCapRatio = 0.5f;
+        double epsCov = 1e-8f;
+        double lamGeo = 1.0f;
+        double lamSh = 1.0f;
+        double pCapRatio = 0.5f;
         
         logger.log(level, "Simplify " + splats.size() + " with ratio " + ratio);
         long beforeNs = System.nanoTime();
@@ -75,7 +75,7 @@ public class NanoGs
             () -> NanoGsPruning.pruneByOpacity(pruneCur, threshold));
         logger.log(level, "Pruning: " + cur.size() + " splats left");
 
-        float[][] Z = NanoGsSampling.makeGaussianSamples(nMc, seed);
+        double[][] Z = NanoGsSampling.makeGaussianSamples(nMc, seed);
 
         int iteration = 0;
         while (cur.size() > target)

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsCaching.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsCaching.java
@@ -1,0 +1,167 @@
+/*
+ * www.javagl.de - JSplat
+ *
+ * Copyright 2026 Marco Hutter - http://www.javagl.de
+ * 
+ * Ported from https://github.com/saliteta/NanoGS
+ * Commit: 62ddc34e230a01c061b762103ef69113f6259e48
+ *
+ * Published under "Attribution-NonCommercial 4.0 International" license.
+ * See the "NanoGS-LICENSE.txt" in the root directory of this project.
+ */
+package de.javagl.jsplat.simplification.incremental.nanogs;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import de.javagl.jsplat.Splat;
+import de.javagl.jsplat.Splats;
+
+/**
+ * Implementation of the caching functionality in NanoGS
+ * 
+ * Ported from https://github.com/saliteta/NanoGS 
+ * Commit: 62ddc34e230a01c061b762103ef69113f6259e48
+ */
+class NanoGsCaching
+{
+    /**
+     * Constant for (2*PI)^1.5
+     */
+    private static final float TWO_PI_POW_1P5 =
+        (float) Math.pow(2.0 * Math.PI, 1.5);
+
+    /**
+     * The cache that is passed to {@link NanoGsCost#fullCostPairCached}
+     */
+    static class Cache
+    {
+        /**
+         * The 3x3 rotation matrices
+         */
+        float[] R;
+
+        /**
+         * The 3x3 rotation matrices, transposed
+         */
+        float[] Rt;
+
+        /**
+         * The 3 variances
+         */
+        float[] v;
+
+        /**
+         * The 3 inverse diagonals
+         */
+        float[] invdiag;
+
+        /**
+         * The 1 logarithm of the determinant
+         */
+        float[] logdet;
+
+        /**
+         * The 3x3 covariance matrix
+         */
+        float[] sigma;
+
+        /**
+         * The 1 "mass" (alpha times volume)
+         */
+        float[] mass;
+
+        /**
+         * The 3 linear scale values (Not present in the original NanoGS
+         * implementation)
+         */
+        float[] linearScale;
+
+        /**
+         * The 1 alpha value (Not present in the original NanoGS implementation)
+         */
+        float[] alpha;
+
+        /**
+         * Creates a new cache with the given size
+         * 
+         * @param N The size
+         */
+        Cache(int N)
+        {
+            R = new float[N * 9];
+            Rt = new float[N * 9];
+            v = new float[N * 3];
+            invdiag = new float[N * 3];
+            logdet = new float[N];
+            sigma = new float[N * 9];
+            mass = new float[N];
+            linearScale = new float[N * 3];
+            alpha = new float[N];
+        }
+    }
+
+    /**
+     * Create the cache for the given splats
+     * 
+     * @param state The splats
+     * @param epsCov The epsilon to add for covariance computations
+     * @return The cache
+     */
+    static Cache buildPerSplatCache(List<? extends Splat> state, float epsCov)
+    {
+        int N = state.size();
+
+        Cache c = new Cache(N);
+        IntStream.range(0, N).parallel().forEach(i ->
+        {
+            int i3 = i * 3;
+            int i9 = i * 9;
+
+            Splat s = state.get(i);
+
+            float sx = (float) Math.exp(s.getScaleX());
+            float sy = (float) Math.exp(s.getScaleY());
+            float sz = (float) Math.exp(s.getScaleZ());
+
+            c.linearScale[i3 + 0] = sx;
+            c.linearScale[i3 + 1] = sy;
+            c.linearScale[i3 + 2] = sz;
+
+            float vx = sx * sx + epsCov;
+            float vy = sy * sy + epsCov;
+            float vz = sz * sz + epsCov;
+
+            c.v[i3 + 0] = vx;
+            c.v[i3 + 1] = vy;
+            c.v[i3 + 2] = vz;
+
+            double cvx = Math.max(vx, 1e-30);
+            double cvy = Math.max(vy, 1e-30);
+            double cvz = Math.max(vz, 1e-30);
+
+            c.invdiag[i3 + 0] = (float) (1.0 / cvx);
+            c.invdiag[i3 + 1] = (float) (1.0 / cvy);
+            c.invdiag[i3 + 2] = (float) (1.0 / cvz);
+            c.logdet[i] = (float) Math.log(cvx) + (float) Math.log(cvy)
+                + (float) Math.log(cvz);
+
+            float qw = s.getRotationW();
+            float qx = s.getRotationX();
+            float qy = s.getRotationY();
+            float qz = s.getRotationZ();
+            NanoGsMath.quatToRotmatInto(qw, qx, qy, qz, c.R, i9);
+            NanoGsMath.transpose3Into(c.R, i9, c.Rt, i9);
+            NanoGsMath.sigmaFromRotVarInto(c.R, i9, vx, vy, vz, c.sigma, i9);
+
+            float op = s.getOpacity();
+            float alpha = Splats.opacityToAlpha(op);
+            c.alpha[i] = Splats.opacityToAlpha(s.getOpacity());
+
+            c.mass[i] = (float) (TWO_PI_POW_1P5 * alpha * sx * sy * sz + 1e-12);
+        });
+
+        return c;
+    }
+
+}

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsCaching.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsCaching.java
@@ -28,8 +28,8 @@ class NanoGsCaching
     /**
      * Constant for (2*PI)^1.5
      */
-    private static final float TWO_PI_POW_1P5 =
-        (float) Math.pow(2.0 * Math.PI, 1.5);
+    private static final double TWO_PI_POW_1P5 =
+        Math.pow(2.0 * Math.PI, 1.5);
 
     /**
      * The cache that is passed to {@link NanoGsCost#fullCostPairCached}
@@ -39,48 +39,48 @@ class NanoGsCaching
         /**
          * The 3x3 rotation matrices
          */
-        float[] R;
+        double[] R;
 
         /**
          * The 3x3 rotation matrices, transposed
          */
-        float[] Rt;
+        double[] Rt;
 
         /**
          * The 3 variances
          */
-        float[] v;
+        double[] v;
 
         /**
          * The 3 inverse diagonals
          */
-        float[] invdiag;
+        double[] invdiag;
 
         /**
          * The 1 logarithm of the determinant
          */
-        float[] logdet;
+        double[] logdet;
 
         /**
          * The 3x3 covariance matrix
          */
-        float[] sigma;
+        double[] sigma;
 
         /**
          * The 1 "mass" (alpha times volume)
          */
-        float[] mass;
+        double[] mass;
 
         /**
          * The 3 linear scale values (Not present in the original NanoGS
          * implementation)
          */
-        float[] linearScale;
+        double[] linearScale;
 
         /**
          * The 1 alpha value (Not present in the original NanoGS implementation)
          */
-        float[] alpha;
+        double[] alpha;
 
         /**
          * Creates a new cache with the given size
@@ -89,15 +89,15 @@ class NanoGsCaching
          */
         Cache(int N)
         {
-            R = new float[N * 9];
-            Rt = new float[N * 9];
-            v = new float[N * 3];
-            invdiag = new float[N * 3];
-            logdet = new float[N];
-            sigma = new float[N * 9];
-            mass = new float[N];
-            linearScale = new float[N * 3];
-            alpha = new float[N];
+            R = new double[N * 9];
+            Rt = new double[N * 9];
+            v = new double[N * 3];
+            invdiag = new double[N * 3];
+            logdet = new double[N];
+            sigma = new double[N * 9];
+            mass = new double[N];
+            linearScale = new double[N * 3];
+            alpha = new double[N];
         }
     }
 
@@ -108,7 +108,7 @@ class NanoGsCaching
      * @param epsCov The epsilon to add for covariance computations
      * @return The cache
      */
-    static Cache buildPerSplatCache(List<? extends Splat> state, float epsCov)
+    static Cache buildPerSplatCache(List<? extends Splat> state, double epsCov)
     {
         int N = state.size();
 
@@ -120,17 +120,17 @@ class NanoGsCaching
 
             Splat s = state.get(i);
 
-            float sx = (float) Math.exp(s.getScaleX());
-            float sy = (float) Math.exp(s.getScaleY());
-            float sz = (float) Math.exp(s.getScaleZ());
+            double sx = Math.exp(s.getScaleX());
+            double sy = Math.exp(s.getScaleY());
+            double sz = Math.exp(s.getScaleZ());
 
             c.linearScale[i3 + 0] = sx;
             c.linearScale[i3 + 1] = sy;
             c.linearScale[i3 + 2] = sz;
 
-            float vx = sx * sx + epsCov;
-            float vy = sy * sy + epsCov;
-            float vz = sz * sz + epsCov;
+            double vx = sx * sx + epsCov;
+            double vy = sy * sy + epsCov;
+            double vz = sz * sz + epsCov;
 
             c.v[i3 + 0] = vx;
             c.v[i3 + 1] = vy;
@@ -140,25 +140,24 @@ class NanoGsCaching
             double cvy = Math.max(vy, 1e-30);
             double cvz = Math.max(vz, 1e-30);
 
-            c.invdiag[i3 + 0] = (float) (1.0 / cvx);
-            c.invdiag[i3 + 1] = (float) (1.0 / cvy);
-            c.invdiag[i3 + 2] = (float) (1.0 / cvz);
-            c.logdet[i] = (float) Math.log(cvx) + (float) Math.log(cvy)
-                + (float) Math.log(cvz);
+            c.invdiag[i3 + 0] = 1.0 / cvx;
+            c.invdiag[i3 + 1] = 1.0 / cvy;
+            c.invdiag[i3 + 2] = 1.0 / cvz;
+            c.logdet[i] = Math.log(cvx) + Math.log(cvy) + Math.log(cvz);
 
-            float qw = s.getRotationW();
-            float qx = s.getRotationX();
-            float qy = s.getRotationY();
-            float qz = s.getRotationZ();
+            double qw = s.getRotationW();
+            double qx = s.getRotationX();
+            double qy = s.getRotationY();
+            double qz = s.getRotationZ();
             NanoGsMath.quatToRotmatInto(qw, qx, qy, qz, c.R, i9);
             NanoGsMath.transpose3Into(c.R, i9, c.Rt, i9);
             NanoGsMath.sigmaFromRotVarInto(c.R, i9, vx, vy, vz, c.sigma, i9);
 
-            float op = s.getOpacity();
-            float alpha = Splats.opacityToAlpha(op);
+            double op = s.getOpacity();
+            double alpha = Splats.opacityToAlpha(op);
             c.alpha[i] = Splats.opacityToAlpha(s.getOpacity());
 
-            c.mass[i] = (float) (TWO_PI_POW_1P5 * alpha * sx * sy * sz + 1e-12);
+            c.mass[i] = TWO_PI_POW_1P5 * alpha * sx * sy * sz + 1e-12;
         });
 
         return c;

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsCost.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsCost.java
@@ -1,0 +1,295 @@
+/*
+ * www.javagl.de - JSplat
+ *
+ * Copyright 2026 Marco Hutter - http://www.javagl.de
+ * 
+ * Ported from https://github.com/saliteta/NanoGS
+ * Commit: 62ddc34e230a01c061b762103ef69113f6259e48
+ *
+ * Published under "Attribution-NonCommercial 4.0 International" license.
+ * See the "NanoGS-LICENSE.txt" in the root directory of this project.
+ */
+package de.javagl.jsplat.simplification.incremental.nanogs;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import de.javagl.jsplat.Splat;
+import de.javagl.jsplat.simplification.incremental.Edge;
+import de.javagl.jsplat.simplification.incremental.nanogs.NanoGsCaching.Cache;
+
+/**
+ * Implementation of the merge cost computation from NanoGS
+ * 
+ * Ported from https://github.com/saliteta/NanoGS 
+ * Commit: 62ddc34e230a01c061b762103ef69113f6259e48
+ */
+class NanoGsCost
+{
+    /**
+     * Constant for (2*PI)^1.5
+     */
+    private static final float TWO_PI_POW_1P5 =
+        (float) Math.pow(2.0 * Math.PI, 1.5);
+
+    /**
+     * Constant for log(2*PI)
+     */
+    private static float LOG2PI = (float) Math.log(2.0 * Math.PI);
+
+    /**
+     * A thread-local 3x3 matrix for "Sigm"
+     */
+    private static final ThreadLocal<float[]> THREAD_LOCAL_Sigm =
+        ThreadLocal.withInitial(() -> new float[9]);        
+    
+    /**
+     * Compute the weights for the given edges
+     * 
+     * @param cur The current splats
+     * @param edges The edges
+     * @param Z The gaussian samples
+     * @param epsCov The epsilon to add to the covariance computation
+     * @param lamGeo The weight for the geometry part
+     * @param lamSh The weight for the SH part
+     */
+    static void computeWeights(List<? extends Splat> cur, List<Edge> edges,
+        float Z[][], float epsCov, float lamGeo, float lamSh)
+    {
+        Cache cache = NanoGsCaching.buildPerSplatCache(cur, epsCov);
+        int n = edges.size();
+        IntStream.range(0, n).parallel().forEach(i ->
+        {
+            Edge edge = edges.get(i);
+            Splat s0 = cur.get(edge.i0);
+            Splat s1 = cur.get(edge.i1);
+            float distance = NanoGsCost.fullCostPairCached(edge.i0, s0, edge.i1,
+                s1, cache, Z, lamGeo, lamSh);
+            edge.weight = distance;
+        });
+    }
+
+    /**
+     * Computes the cost for the specified edge.
+     * 
+     * Location: scripts/simplify.js#L445
+     * 
+     * @param i The index of the first splat
+     * @param splatI The first splat
+     * @param j The index of the second splat
+     * @param splatJ The second splat
+     * @param cache The {@link Cache}
+     * @param Z The gaussian samples
+     * @param lamGeo The weight for the geometry part
+     * @param lamSh The weight for the SH part
+     * @return The cost
+     */
+    private static float fullCostPairCached(int i, Splat splatI, int j,
+        Splat splatJ, Cache cache, float[][] Z, float lamGeo, float lamSh)
+    {
+        int i3 = i * 3;
+        int j3 = j * 3;
+        int i9 = i * 9;
+        int j9 = j * 9;
+
+        float cpEpsCov = 1e-8f;
+
+        float mux = splatI.getPositionX();
+        float muy = splatI.getPositionY();
+        float muz = splatI.getPositionZ();
+
+        float mvx = splatJ.getPositionX();
+        float mvy = splatJ.getPositionY();
+        float mvz = splatJ.getPositionZ();
+
+        float scaleIx = cache.linearScale[i3 + 0];
+        float scaleIy = cache.linearScale[i3 + 1];
+        float scaleIz = cache.linearScale[i3 + 2];
+
+        float scaleJx = cache.linearScale[j3 + 0];
+        float scaleJy = cache.linearScale[j3 + 1];
+        float scaleJz = cache.linearScale[j3 + 2];
+
+        float alphaI = cache.alpha[i];
+        float alphaJ = cache.alpha[j];
+        float scaleI = scaleIx * scaleIy * scaleIz;
+        float scaleJ = scaleJx * scaleJy * scaleJz;
+        float wi = TWO_PI_POW_1P5 * alphaI * scaleI + 1e-12f;
+        float wj = TWO_PI_POW_1P5 * alphaJ * scaleJ + 1e-12f;
+        float W = wi + wj;
+        float Wsafe = W > 0 ? W : 1.0f;
+
+        float pi = wi / Wsafe;
+        pi = Math.min(1 - 1e-12f, Math.max(1e-12f, pi));
+        float pj = 1.0f - pi;
+        float logPi = (float) Math.log(pi);
+        float logPj = (float) Math.log(pj);
+
+        float mmx = pi * mux + pj * mvx;
+        float mmy = pi * muy + pj * mvy;
+        float mmz = pi * muz + pj * mvz;
+
+        float dix = mux - mmx;
+        float diy = muy - mmy;
+        float diz = muz - mmz;
+        float djx = mvx - mmx;
+        float djy = mvy - mmy;
+        float djz = mvz - mmz;
+
+        float Sigm[] = THREAD_LOCAL_Sigm.get();
+        for (int a = 0; a < 9; a++)
+        {
+            Sigm[a] = pi * cache.sigma[i9 + a] + pj * cache.sigma[j9 + a];
+        }
+
+        Sigm[0] += pi * dix * dix + pj * djx * djx;
+        Sigm[1] += pi * dix * diy + pj * djx * djy;
+        Sigm[2] += pi * dix * diz + pj * djx * djz;
+        Sigm[3] += pi * diy * dix + pj * djy * djx;
+        Sigm[4] += pi * diy * diy + pj * djy * djy;
+        Sigm[5] += pi * diy * diz + pj * djy * djz;
+        Sigm[6] += pi * diz * dix + pj * djz * djx;
+        Sigm[7] += pi * diz * diy + pj * djz * djy;
+        Sigm[8] += pi * diz * diz + pj * djz * djz;
+
+        float s01 = 0.5f * (Sigm[1] + Sigm[3]);
+        float s02 = 0.5f * (Sigm[2] + Sigm[6]);
+        float s12 = 0.5f * (Sigm[5] + Sigm[7]);
+        Sigm[1] = Sigm[3] = s01;
+        Sigm[2] = Sigm[6] = s02;
+        Sigm[5] = Sigm[7] = s12;
+        Sigm[0] += cpEpsCov;
+        Sigm[4] += cpEpsCov;
+        Sigm[8] += cpEpsCov;
+
+        float detm = Math.max(NanoGsMath.det3Flat(Sigm), 1e-30f);
+        float logdetm = (float) Math.log(detm);
+
+        float EpNegLogQ = (float) (0.5 * (3.0 * LOG2PI + logdetm + 3.0));
+
+        float stdix = (float) Math.sqrt(Math.max(cache.v[i3 + 0], 0));
+        float stdiy = (float) Math.sqrt(Math.max(cache.v[i3 + 1], 0));
+        float stdiz = (float) Math.sqrt(Math.max(cache.v[i3 + 2], 0));
+
+        float stdjx = (float) Math.sqrt(Math.max(cache.v[j3 + 0], 0));
+        float stdjy = (float) Math.sqrt(Math.max(cache.v[j3 + 1], 0));
+        float stdjz = (float) Math.sqrt(Math.max(cache.v[j3 + 2], 0));
+
+        float sumLogpOnI = 0.0f;
+        float sumLogpOnJ = 0.0f;
+
+        for (int s = 0; s < Z.length; s++)
+        {
+            float z0 = Z[s][0];
+            float z1 = Z[s][1];
+            float z2 = Z[s][2];
+
+            float xix = mux + z0 * stdix * cache.Rt[i9]
+                + z1 * stdiy * cache.Rt[i9 + 3] + z2 * stdiz * cache.Rt[i9 + 6];
+            float xiy = muy + z0 * stdix * cache.Rt[i9 + 1]
+                + z1 * stdiy * cache.Rt[i9 + 4] + z2 * stdiz * cache.Rt[i9 + 7];
+            float xiz = muz + z0 * stdix * cache.Rt[i9 + 2]
+                + z1 * stdiy * cache.Rt[i9 + 5] + z2 * stdiz * cache.Rt[i9 + 8];
+
+            float xjx = mvx + z0 * stdjx * cache.Rt[j9]
+                + z1 * stdjy * cache.Rt[j9 + 3] + z2 * stdjz * cache.Rt[j9 + 6];
+            float xjy = mvy + z0 * stdjx * cache.Rt[j9 + 1]
+                + z1 * stdjy * cache.Rt[j9 + 4] + z2 * stdjz * cache.Rt[j9 + 7];
+            float xjz = mvz + z0 * stdjx * cache.Rt[j9 + 2]
+                + z1 * stdjy * cache.Rt[j9 + 5] + z2 * stdjz * cache.Rt[j9 + 8];
+
+            float logNiOnI = gaussLogpdfDiagrotFlat(xix, xiy, xiz, mux, muy,
+                muz, cache.R, i9, cache.invdiag[i3], cache.invdiag[i3 + 1],
+                cache.invdiag[i3 + 2], cache.logdet[i]);
+            float logNjOnI = gaussLogpdfDiagrotFlat(xix, xiy, xiz, mvx, mvy,
+                mvz, cache.R, j9, cache.invdiag[j3], cache.invdiag[j3 + 1],
+                cache.invdiag[j3 + 2], cache.logdet[j]);
+            sumLogpOnI += logAddExp(logPi + logNiOnI, logPj + logNjOnI);
+
+            float logNiOnJ = gaussLogpdfDiagrotFlat(xjx, xjy, xjz, mux, muy,
+                muz, cache.R, i9, cache.invdiag[i3], cache.invdiag[i3 + 1],
+                cache.invdiag[i3 + 2], cache.logdet[i]);
+            float logNjOnJ = gaussLogpdfDiagrotFlat(xjx, xjy, xjz, mvx, mvy,
+                mvz, cache.R, j9, cache.invdiag[j3], cache.invdiag[j3 + 1],
+                cache.invdiag[j3 + 2], cache.logdet[j]);
+            sumLogpOnJ += logAddExp(logPi + logNiOnJ, logPj + logNjOnJ);
+        }
+
+        float Ei = sumLogpOnI / Z.length;
+        float Ej = sumLogpOnJ / Z.length;
+        float EpLogp = pi * Ei + pj * Ej;
+        float geo = EpLogp + EpNegLogQ;
+
+        float cSh = 0.0f;
+        int shDim = splatI.getShDimensions();
+        for (int k = 0; k < shDim; k++)
+        {
+            float dX = splatI.getShX(k) - splatJ.getShX(k);
+            float dY = splatI.getShY(k) - splatJ.getShY(k);
+            float dZ = splatI.getShZ(k) - splatJ.getShZ(k);
+            cSh += dX * dX;
+            cSh += dY * dY;
+            cSh += dZ * dZ;
+        }
+        return lamGeo * geo + lamSh * cSh;
+    }
+
+    /**
+     * Computes the logarithm of the sum of the exponents of the given values.
+     * 
+     * Ported from https://github.com/RongLiu-Leo/NanoGS Commit:
+     * 9e49497b3f16674aed6ab9204584e14794f82f84 Location:
+     * scripts/simplify.js#L1241
+     * 
+     * @param a The first value
+     * @param b The second value
+     * @return The result
+     */
+    private static float logAddExp(float a, float b)
+    {
+        float m = Math.max(a, b);
+        return (float) (m + Math.log(Math.exp(a - m) + Math.exp(b - m)));
+    }
+
+    /**
+     * Computes the logarithmic probability density function of a 3D point under
+     * a Gaussian distribution with a diagonal covariance matrix that has been
+     * rotated.
+     * 
+     * Ported from https://github.com/RongLiu-Leo/NanoGS/blob Commit: Location:
+     * scripts/simplify.js#L1069
+     * 
+     * @param x The x-coordinate
+     * @param y The y-coordinate
+     * @param z The z-coordinate
+     * @param mx The mean x
+     * @param my The mean y
+     * @param mz The mean z
+     * @param R The array that contains the rotation matrix
+     * @param rOffset The offset in the array
+     * @param invx The inverse of the x-diagonal element of the matrix
+     * @param invy The inverse of the y-diagonal element of the matrix
+     * @param invz The inverse of the z-diagonal element of the matrix
+     * @param logdet The logarithm of the determinant
+     * @return The result
+     */
+    private static float gaussLogpdfDiagrotFlat(float x, float y, float z,
+        float mx, float my, float mz, float R[], int rOffset, float invx,
+        float invy, float invz, float logdet)
+    {
+        float dx = x - mx;
+        float dy = y - my;
+        float dz = z - mz;
+
+        float y0 =
+            dx * R[rOffset + 0] + dy * R[rOffset + 3] + dz * R[rOffset + 6];
+        float y1 =
+            dx * R[rOffset + 1] + dy * R[rOffset + 4] + dz * R[rOffset + 7];
+        float y2 =
+            dx * R[rOffset + 2] + dy * R[rOffset + 5] + dz * R[rOffset + 8];
+
+        float quad = y0 * y0 * invx + y1 * y1 * invy + y2 * y2 * invz;
+        return (float) (-0.5 * (3.0 * LOG2PI + logdet + quad));
+    }
+
+}

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsCost.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsCost.java
@@ -29,19 +29,19 @@ class NanoGsCost
     /**
      * Constant for (2*PI)^1.5
      */
-    private static final float TWO_PI_POW_1P5 =
-        (float) Math.pow(2.0 * Math.PI, 1.5);
+    private static final double TWO_PI_POW_1P5 =
+        Math.pow(2.0 * Math.PI, 1.5);
 
     /**
      * Constant for log(2*PI)
      */
-    private static float LOG2PI = (float) Math.log(2.0 * Math.PI);
+    private static double LOG2PI = Math.log(2.0 * Math.PI);
 
     /**
      * A thread-local 3x3 matrix for "Sigm"
      */
-    private static final ThreadLocal<float[]> THREAD_LOCAL_Sigm =
-        ThreadLocal.withInitial(() -> new float[9]);        
+    private static final ThreadLocal<double[]> THREAD_LOCAL_Sigm =
+        ThreadLocal.withInitial(() -> new double[9]);        
     
     /**
      * Compute the weights for the given edges
@@ -54,7 +54,7 @@ class NanoGsCost
      * @param lamSh The weight for the SH part
      */
     static void computeWeights(List<? extends Splat> cur, List<Edge> edges,
-        float Z[][], float epsCov, float lamGeo, float lamSh)
+        double Z[][], double epsCov, double lamGeo, double lamSh)
     {
         Cache cache = NanoGsCaching.buildPerSplatCache(cur, epsCov);
         int n = edges.size();
@@ -63,7 +63,7 @@ class NanoGsCost
             Edge edge = edges.get(i);
             Splat s0 = cur.get(edge.i0);
             Splat s1 = cur.get(edge.i1);
-            float distance = NanoGsCost.fullCostPairCached(edge.i0, s0, edge.i1,
+            double distance = NanoGsCost.fullCostPairCached(edge.i0, s0, edge.i1,
                 s1, cache, Z, lamGeo, lamSh);
             edge.weight = distance;
         });
@@ -84,59 +84,59 @@ class NanoGsCost
      * @param lamSh The weight for the SH part
      * @return The cost
      */
-    private static float fullCostPairCached(int i, Splat splatI, int j,
-        Splat splatJ, Cache cache, float[][] Z, float lamGeo, float lamSh)
+    private static double fullCostPairCached(int i, Splat splatI, int j,
+        Splat splatJ, Cache cache, double[][] Z, double lamGeo, double lamSh)
     {
         int i3 = i * 3;
         int j3 = j * 3;
         int i9 = i * 9;
         int j9 = j * 9;
 
-        float cpEpsCov = 1e-8f;
+        double cpEpsCov = 1e-8;
 
-        float mux = splatI.getPositionX();
-        float muy = splatI.getPositionY();
-        float muz = splatI.getPositionZ();
+        double mux = splatI.getPositionX();
+        double muy = splatI.getPositionY();
+        double muz = splatI.getPositionZ();
 
-        float mvx = splatJ.getPositionX();
-        float mvy = splatJ.getPositionY();
-        float mvz = splatJ.getPositionZ();
+        double mvx = splatJ.getPositionX();
+        double mvy = splatJ.getPositionY();
+        double mvz = splatJ.getPositionZ();
 
-        float scaleIx = cache.linearScale[i3 + 0];
-        float scaleIy = cache.linearScale[i3 + 1];
-        float scaleIz = cache.linearScale[i3 + 2];
+        double scaleIx = cache.linearScale[i3 + 0];
+        double scaleIy = cache.linearScale[i3 + 1];
+        double scaleIz = cache.linearScale[i3 + 2];
 
-        float scaleJx = cache.linearScale[j3 + 0];
-        float scaleJy = cache.linearScale[j3 + 1];
-        float scaleJz = cache.linearScale[j3 + 2];
+        double scaleJx = cache.linearScale[j3 + 0];
+        double scaleJy = cache.linearScale[j3 + 1];
+        double scaleJz = cache.linearScale[j3 + 2];
 
-        float alphaI = cache.alpha[i];
-        float alphaJ = cache.alpha[j];
-        float scaleI = scaleIx * scaleIy * scaleIz;
-        float scaleJ = scaleJx * scaleJy * scaleJz;
-        float wi = TWO_PI_POW_1P5 * alphaI * scaleI + 1e-12f;
-        float wj = TWO_PI_POW_1P5 * alphaJ * scaleJ + 1e-12f;
-        float W = wi + wj;
-        float Wsafe = W > 0 ? W : 1.0f;
+        double alphaI = cache.alpha[i];
+        double alphaJ = cache.alpha[j];
+        double scaleI = scaleIx * scaleIy * scaleIz;
+        double scaleJ = scaleJx * scaleJy * scaleJz;
+        double wi = TWO_PI_POW_1P5 * alphaI * scaleI + 1e-12;
+        double wj = TWO_PI_POW_1P5 * alphaJ * scaleJ + 1e-12;
+        double W = wi + wj;
+        double Wsafe = W > 0 ? W : 1.0;
 
-        float pi = wi / Wsafe;
-        pi = Math.min(1 - 1e-12f, Math.max(1e-12f, pi));
-        float pj = 1.0f - pi;
-        float logPi = (float) Math.log(pi);
-        float logPj = (float) Math.log(pj);
+        double pi = wi / Wsafe;
+        pi = Math.min(1 - 1e-12, Math.max(1e-12, pi));
+        double pj = 1.0 - pi;
+        double logPi = Math.log(pi);
+        double logPj = Math.log(pj);
 
-        float mmx = pi * mux + pj * mvx;
-        float mmy = pi * muy + pj * mvy;
-        float mmz = pi * muz + pj * mvz;
+        double mmx = pi * mux + pj * mvx;
+        double mmy = pi * muy + pj * mvy;
+        double mmz = pi * muz + pj * mvz;
 
-        float dix = mux - mmx;
-        float diy = muy - mmy;
-        float diz = muz - mmz;
-        float djx = mvx - mmx;
-        float djy = mvy - mmy;
-        float djz = mvz - mmz;
+        double dix = mux - mmx;
+        double diy = muy - mmy;
+        double diz = muz - mmz;
+        double djx = mvx - mmx;
+        double djy = mvy - mmy;
+        double djz = mvz - mmz;
 
-        float Sigm[] = THREAD_LOCAL_Sigm.get();
+        double Sigm[] = THREAD_LOCAL_Sigm.get();
         for (int a = 0; a < 9; a++)
         {
             Sigm[a] = pi * cache.sigma[i9 + a] + pj * cache.sigma[j9 + a];
@@ -152,9 +152,9 @@ class NanoGsCost
         Sigm[7] += pi * diz * diy + pj * djz * djy;
         Sigm[8] += pi * diz * diz + pj * djz * djz;
 
-        float s01 = 0.5f * (Sigm[1] + Sigm[3]);
-        float s02 = 0.5f * (Sigm[2] + Sigm[6]);
-        float s12 = 0.5f * (Sigm[5] + Sigm[7]);
+        double s01 = 0.5 * (Sigm[1] + Sigm[3]);
+        double s02 = 0.5 * (Sigm[2] + Sigm[6]);
+        double s12 = 0.5 * (Sigm[5] + Sigm[7]);
         Sigm[1] = Sigm[3] = s01;
         Sigm[2] = Sigm[6] = s02;
         Sigm[5] = Sigm[7] = s12;
@@ -162,71 +162,71 @@ class NanoGsCost
         Sigm[4] += cpEpsCov;
         Sigm[8] += cpEpsCov;
 
-        float detm = Math.max(NanoGsMath.det3Flat(Sigm), 1e-30f);
-        float logdetm = (float) Math.log(detm);
+        double detm = Math.max(NanoGsMath.det3Flat(Sigm), 1e-30);
+        double logdetm = Math.log(detm);
 
-        float EpNegLogQ = (float) (0.5 * (3.0 * LOG2PI + logdetm + 3.0));
+        double EpNegLogQ = 0.5 * (3.0 * LOG2PI + logdetm + 3.0);
 
-        float stdix = (float) Math.sqrt(Math.max(cache.v[i3 + 0], 0));
-        float stdiy = (float) Math.sqrt(Math.max(cache.v[i3 + 1], 0));
-        float stdiz = (float) Math.sqrt(Math.max(cache.v[i3 + 2], 0));
+        double stdix = Math.sqrt(Math.max(cache.v[i3 + 0], 0));
+        double stdiy = Math.sqrt(Math.max(cache.v[i3 + 1], 0));
+        double stdiz = Math.sqrt(Math.max(cache.v[i3 + 2], 0));
 
-        float stdjx = (float) Math.sqrt(Math.max(cache.v[j3 + 0], 0));
-        float stdjy = (float) Math.sqrt(Math.max(cache.v[j3 + 1], 0));
-        float stdjz = (float) Math.sqrt(Math.max(cache.v[j3 + 2], 0));
+        double stdjx = Math.sqrt(Math.max(cache.v[j3 + 0], 0));
+        double stdjy = Math.sqrt(Math.max(cache.v[j3 + 1], 0));
+        double stdjz = Math.sqrt(Math.max(cache.v[j3 + 2], 0));
 
-        float sumLogpOnI = 0.0f;
-        float sumLogpOnJ = 0.0f;
+        double sumLogpOnI = 0.0;
+        double sumLogpOnJ = 0.0;
 
         for (int s = 0; s < Z.length; s++)
         {
-            float z0 = Z[s][0];
-            float z1 = Z[s][1];
-            float z2 = Z[s][2];
+            double z0 = Z[s][0];
+            double z1 = Z[s][1];
+            double z2 = Z[s][2];
 
-            float xix = mux + z0 * stdix * cache.Rt[i9]
+            double xix = mux + z0 * stdix * cache.Rt[i9]
                 + z1 * stdiy * cache.Rt[i9 + 3] + z2 * stdiz * cache.Rt[i9 + 6];
-            float xiy = muy + z0 * stdix * cache.Rt[i9 + 1]
+            double xiy = muy + z0 * stdix * cache.Rt[i9 + 1]
                 + z1 * stdiy * cache.Rt[i9 + 4] + z2 * stdiz * cache.Rt[i9 + 7];
-            float xiz = muz + z0 * stdix * cache.Rt[i9 + 2]
+            double xiz = muz + z0 * stdix * cache.Rt[i9 + 2]
                 + z1 * stdiy * cache.Rt[i9 + 5] + z2 * stdiz * cache.Rt[i9 + 8];
 
-            float xjx = mvx + z0 * stdjx * cache.Rt[j9]
+            double xjx = mvx + z0 * stdjx * cache.Rt[j9]
                 + z1 * stdjy * cache.Rt[j9 + 3] + z2 * stdjz * cache.Rt[j9 + 6];
-            float xjy = mvy + z0 * stdjx * cache.Rt[j9 + 1]
+            double xjy = mvy + z0 * stdjx * cache.Rt[j9 + 1]
                 + z1 * stdjy * cache.Rt[j9 + 4] + z2 * stdjz * cache.Rt[j9 + 7];
-            float xjz = mvz + z0 * stdjx * cache.Rt[j9 + 2]
+            double xjz = mvz + z0 * stdjx * cache.Rt[j9 + 2]
                 + z1 * stdjy * cache.Rt[j9 + 5] + z2 * stdjz * cache.Rt[j9 + 8];
 
-            float logNiOnI = gaussLogpdfDiagrotFlat(xix, xiy, xiz, mux, muy,
+            double logNiOnI = gaussLogpdfDiagrotFlat(xix, xiy, xiz, mux, muy,
                 muz, cache.R, i9, cache.invdiag[i3], cache.invdiag[i3 + 1],
                 cache.invdiag[i3 + 2], cache.logdet[i]);
-            float logNjOnI = gaussLogpdfDiagrotFlat(xix, xiy, xiz, mvx, mvy,
+            double logNjOnI = gaussLogpdfDiagrotFlat(xix, xiy, xiz, mvx, mvy,
                 mvz, cache.R, j9, cache.invdiag[j3], cache.invdiag[j3 + 1],
                 cache.invdiag[j3 + 2], cache.logdet[j]);
             sumLogpOnI += logAddExp(logPi + logNiOnI, logPj + logNjOnI);
 
-            float logNiOnJ = gaussLogpdfDiagrotFlat(xjx, xjy, xjz, mux, muy,
+            double logNiOnJ = gaussLogpdfDiagrotFlat(xjx, xjy, xjz, mux, muy,
                 muz, cache.R, i9, cache.invdiag[i3], cache.invdiag[i3 + 1],
                 cache.invdiag[i3 + 2], cache.logdet[i]);
-            float logNjOnJ = gaussLogpdfDiagrotFlat(xjx, xjy, xjz, mvx, mvy,
+            double logNjOnJ = gaussLogpdfDiagrotFlat(xjx, xjy, xjz, mvx, mvy,
                 mvz, cache.R, j9, cache.invdiag[j3], cache.invdiag[j3 + 1],
                 cache.invdiag[j3 + 2], cache.logdet[j]);
             sumLogpOnJ += logAddExp(logPi + logNiOnJ, logPj + logNjOnJ);
         }
 
-        float Ei = sumLogpOnI / Z.length;
-        float Ej = sumLogpOnJ / Z.length;
-        float EpLogp = pi * Ei + pj * Ej;
-        float geo = EpLogp + EpNegLogQ;
+        double Ei = sumLogpOnI / Z.length;
+        double Ej = sumLogpOnJ / Z.length;
+        double EpLogp = pi * Ei + pj * Ej;
+        double geo = EpLogp + EpNegLogQ;
 
-        float cSh = 0.0f;
+        double cSh = 0.0;
         int shDim = splatI.getShDimensions();
         for (int k = 0; k < shDim; k++)
         {
-            float dX = splatI.getShX(k) - splatJ.getShX(k);
-            float dY = splatI.getShY(k) - splatJ.getShY(k);
-            float dZ = splatI.getShZ(k) - splatJ.getShZ(k);
+            double dX = splatI.getShX(k) - splatJ.getShX(k);
+            double dY = splatI.getShY(k) - splatJ.getShY(k);
+            double dZ = splatI.getShZ(k) - splatJ.getShZ(k);
             cSh += dX * dX;
             cSh += dY * dY;
             cSh += dZ * dZ;
@@ -245,10 +245,10 @@ class NanoGsCost
      * @param b The second value
      * @return The result
      */
-    private static float logAddExp(float a, float b)
+    private static double logAddExp(double a, double b)
     {
-        float m = Math.max(a, b);
-        return (float) (m + Math.log(Math.exp(a - m) + Math.exp(b - m)));
+        double m = Math.max(a, b);
+        return m + Math.log(Math.exp(a - m) + Math.exp(b - m));
     }
 
     /**
@@ -273,23 +273,23 @@ class NanoGsCost
      * @param logdet The logarithm of the determinant
      * @return The result
      */
-    private static float gaussLogpdfDiagrotFlat(float x, float y, float z,
-        float mx, float my, float mz, float R[], int rOffset, float invx,
-        float invy, float invz, float logdet)
+    private static double gaussLogpdfDiagrotFlat(double x, double y, double z,
+        double mx, double my, double mz, double R[], int rOffset, double invx,
+        double invy, double invz, double logdet)
     {
-        float dx = x - mx;
-        float dy = y - my;
-        float dz = z - mz;
+        double dx = x - mx;
+        double dy = y - my;
+        double dz = z - mz;
 
-        float y0 =
+        double y0 =
             dx * R[rOffset + 0] + dy * R[rOffset + 3] + dz * R[rOffset + 6];
-        float y1 =
+        double y1 =
             dx * R[rOffset + 1] + dy * R[rOffset + 4] + dz * R[rOffset + 7];
-        float y2 =
+        double y2 =
             dx * R[rOffset + 2] + dy * R[rOffset + 5] + dz * R[rOffset + 8];
 
-        float quad = y0 * y0 * invx + y1 * y1 * invy + y2 * y2 * invz;
-        return (float) (-0.5 * (3.0 * LOG2PI + logdet + quad));
+        double quad = y0 * y0 * invx + y1 * y1 * invy + y2 * y2 * invz;
+        return -0.5 * (3.0 * LOG2PI + logdet + quad);
     }
 
 }

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsMath.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsMath.java
@@ -1,0 +1,391 @@
+/*
+ * www.javagl.de - JSplat
+ *
+ * Copyright 2026 Marco Hutter - http://www.javagl.de
+ * 
+ * Ported from https://github.com/saliteta/NanoGS
+ * Commit: 62ddc34e230a01c061b762103ef69113f6259e48
+ *
+ * Published under "Attribution-NonCommercial 4.0 International" license.
+ * See the "NanoGS-LICENSE.txt" in the root directory of this project.
+ */
+package de.javagl.jsplat.simplification.incremental.nanogs;
+
+import java.util.Arrays;
+
+/**
+ * Low-level math utility functions for NanoGS.
+ * 
+ * Ported from https://github.com/saliteta/NanoGS
+ * Commit: 62ddc34e230a01c061b762103ef69113f6259e48
+ */
+class NanoGsMath
+{
+    /**
+     * A thread-local 3x3 matrix for "R"
+     */
+    private static final ThreadLocal<float[]> THREAD_LOCAL_R =
+        ThreadLocal.withInitial(() -> new float[9]);        
+
+    /**
+     * A thread-local 3x3 matrix for "matrix"
+     */
+    private static final ThreadLocal<float[]> THREAD_LOCAL_matrix =
+        ThreadLocal.withInitial(() -> new float[9]);        
+
+    /**
+     * A container for the results of an eigendecomposition
+     */
+    static class Eigendecomposition3x3
+    {
+        /**
+         * The eigenvalues
+         */
+        final float[] eigenvalues = new float[3];
+
+        /**
+         * The eigenvectors, as a flat 9-element array
+         */
+        final float[] eigenvectors = new float[9];
+    }
+
+    /**
+     * Computes the determinant of the 3x3 matrix 
+     * 
+     * @param A The input array
+     * @return The determinant
+     */
+    static float det3Flat(float A[])
+    {
+        float a00 = A[0];
+        float a01 = A[1];
+        float a02 = A[2];
+        float a10 = A[3];
+        float a11 = A[4];
+        float a12 = A[5];
+        float a20 = A[6];
+        float a21 = A[7];
+        float a22 = A[8];
+        return (a00 * (a11 * a22 - a12 * a21) - a01 * (a10 * a22 - a12 * a20)
+            + a02 * (a10 * a21 - a11 * a20));
+    }
+
+    /**
+     * Computes a scalar-FIRST quaternion from the 3x3 matrix and stores it
+     * in the given array.
+     * 
+     * @param R The array
+     * @param q The output
+     */
+    static void rotmatToQuatFlat(float R[], float q[])
+    {
+        float m00 = R[0];
+        float m11 = R[4];
+        float m22 = R[8];
+        float tr = m00 + m11 + m22;
+        float qw, qx, qy, qz;
+
+        if (tr > 0)
+        {
+            float S = (float) Math.sqrt(tr + 1.0) * 2.0f;
+            qw = 0.25f * S;
+            qx = (R[7] - R[5]) / S;
+            qy = (R[2] - R[6]) / S;
+            qz = (R[3] - R[1]) / S;
+        }
+        else if (m00 > m11 && m00 > m22)
+        {
+            float S = (float) Math.sqrt(1.0 + m00 - m11 - m22) * 2.0f;
+            qw = (R[7] - R[5]) / S;
+            qx = 0.25f * S;
+            qy = (R[1] + R[3]) / S;
+            qz = (R[2] + R[6]) / S;
+        }
+        else if (m11 > m22)
+        {
+            float S = (float) Math.sqrt(1.0 + m11 - m00 - m22) * 2.0f;
+            qw = (R[2] - R[6]) / S;
+            qx = (R[1] + R[3]) / S;
+            qy = 0.25f * S;
+            qz = (R[5] + R[7]) / S;
+        }
+        else
+        {
+            float S = (float) Math.sqrt(1.0 + m22 - m00 - m11) * 2.0f;
+            qw = (R[3] - R[1]) / S;
+            qx = (R[2] + R[6]) / S;
+            qy = (R[5] + R[7]) / S;
+            qz = 0.25f * S;
+        }
+        q[0] = qw;
+        q[1] = qx;
+        q[2] = qy;
+        q[3] = qz;
+        normalize(q);
+    }
+
+    /**
+     * Normalize the given quaternion in place
+     * 
+     * @param q The quaternion
+     */
+    private static void normalize(float[] q)
+    {
+        float lenSq = q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3];
+        if (lenSq > 0)
+        {
+            float len = (float) Math.sqrt(lenSq);
+            for (int i = 0; i < 4; i++)
+            {
+                q[i] /= len;
+            }
+        }
+    }
+
+    /**
+     * Read the 3x3 matrix from the given source array at the given offset, and
+     * write it in transposed form into the given target array at the given
+     * offset
+     * 
+     * @param src The source array
+     * @param sOffset The sourceOffset
+     * @param dst The target array
+     * @param dOffset The target offset
+     */
+    static void transpose3Into(float src[], int sOffset, float dst[],
+        int dOffset)
+    {
+        dst[dOffset + 0] = src[sOffset + 0];
+        dst[dOffset + 1] = src[sOffset + 3];
+        dst[dOffset + 2] = src[sOffset + 6];
+        dst[dOffset + 3] = src[sOffset + 1];
+        dst[dOffset + 4] = src[sOffset + 4];
+        dst[dOffset + 5] = src[sOffset + 7];
+        dst[dOffset + 6] = src[sOffset + 2];
+        dst[dOffset + 7] = src[sOffset + 5];
+        dst[dOffset + 8] = src[sOffset + 8];
+    }
+
+    /**
+     * Computes the 3x3 covariance matrix (sigma) from the given quaternion and
+     * the given linear scale values
+     * 
+     * @param qw The w-component of the quaternion
+     * @param qx The x-component of the quaternion
+     * @param qy The y-component of the quaternion
+     * @param qz The z-component of the quaternion
+     * @param sx The scale value along x
+     * @param sy The scale value along y
+     * @param sz The scale value along z
+     * @param out The output array
+     */
+    static void sigmaFromQuatScaleFlatInto(float qw, float qx, float qy,
+        float qz, float sx, float sy, float sz, float[] out)
+    {
+        float[] R = THREAD_LOCAL_R.get();
+        quatToRotmatInto(qw, qx, qy, qz, R, 0);
+        sigmaFromRotVarInto(R, 0, sx * sx, sy * sy, sz * sz, out, 0);
+    }
+
+    /**
+     * Write a 3x3 rotation matrix that was computed from the specified
+     * quaternion into the given output array at the given offset
+     * 
+     * @param w The w-component
+     * @param x The x-component
+     * @param y The y-component
+     * @param z The z-component
+     * @param out The output array
+     * @param offset The offset
+     */
+    static void quatToRotmatInto(float w, float x, float y, float z,
+        float out[], int offset)
+    {
+        float xx = x * x;
+        float yy = y * y;
+        float zz = z * z;
+        float wx = w * x;
+        float wy = w * y;
+        float wz = w * z;
+        float xy = x * y;
+        float xz = x * z;
+        float yz = y * z;
+
+        out[offset + 0] = 1 - 2 * (yy + zz);
+        out[offset + 1] = 2 * (xy - wz);
+        out[offset + 2] = 2 * (xz + wy);
+
+        out[offset + 3] = 2 * (xy + wz);
+        out[offset + 4] = 1 - 2 * (xx + zz);
+        out[offset + 5] = 2 * (yz - wx);
+
+        out[offset + 6] = 2 * (xz - wy);
+        out[offset + 7] = 2 * (yz + wx);
+        out[offset + 8] = 1 - 2 * (xx + yy);
+    }
+
+    /**
+     * Computes the 3x3 covariance matrix (sigma) from the given rotation matrix
+     * and the given variances.
+     * 
+     * @param R The array with the 3x3 rotation matrix
+     * @param rOffset The offset in the array where the rotation matrix starts
+     * @param vx The variance along x
+     * @param vy The variance along y
+     * @param vz THe variance along z
+     * @param out The output array
+     * @param oOffset The offset where the output should be written
+     */
+    static void sigmaFromRotVarInto(float R[], int rOffset, float vx, float vy,
+        float vz, float out[], int oOffset)
+    {
+        float r00 = R[rOffset + 0];
+        float r01 = R[rOffset + 1];
+        float r02 = R[rOffset + 2];
+        float r10 = R[rOffset + 3];
+        float r11 = R[rOffset + 4];
+        float r12 = R[rOffset + 5];
+        float r20 = R[rOffset + 6];
+        float r21 = R[rOffset + 7];
+        float r22 = R[rOffset + 8];
+
+        out[oOffset + 0] = r00 * r00 * vx + r01 * r01 * vy + r02 * r02 * vz;
+        out[oOffset + 1] = r00 * r10 * vx + r01 * r11 * vy + r02 * r12 * vz;
+        out[oOffset + 2] = r00 * r20 * vx + r01 * r21 * vy + r02 * r22 * vz;
+
+        out[oOffset + 3] = out[oOffset + 1];
+        out[oOffset + 4] = r10 * r10 * vx + r11 * r11 * vy + r12 * r12 * vz;
+        out[oOffset + 5] = r10 * r20 * vx + r11 * r21 * vy + r12 * r22 * vz;
+
+        out[oOffset + 6] = out[oOffset + 2];
+        out[oOffset + 7] = out[oOffset + 5];
+        out[oOffset + 8] = r20 * r20 * vx + r21 * r21 * vy + r22 * r22 * vz;
+    }
+
+    /**
+     * Compute an eigendecomposition of the given 3x3 matrix
+     * 
+     * @param matrix The matrix
+     * @param result The result
+     */
+    static void eigenSymmetric3x3Flat(float[] matrix, Eigendecomposition3x3 result)
+    {
+        float[] mat = THREAD_LOCAL_matrix.get();
+        System.arraycopy(matrix, 0, mat, 0, 9);
+        float[] V = result.eigenvectors;
+        V[0] = 1.0f;
+        V[1] = 0.0f;
+        V[2] = 0.0f;
+        V[3] = 0.0f;
+        V[4] = 1.0f;
+        V[5] = 0.0f;
+        V[6] = 0.0f;
+        V[7] = 0.0f;
+        V[8] = 1.0f;
+        for (int i = 0; i < 24; i++)
+        {
+            int p = 0;
+            int q = 1;
+            float maxAbs = Math.abs(mat[1]);
+
+            if (Math.abs(mat[2]) > maxAbs)
+            {
+                p = 0;
+                q = 2;
+                maxAbs = Math.abs(mat[2]);
+            }
+            if (Math.abs(mat[5]) > maxAbs)
+            {
+                p = 1;
+                q = 2;
+                maxAbs = Math.abs(mat[5]);
+            }
+
+            if (maxAbs < 1e-12)
+            {
+                break;
+            }
+
+            int pp = 3 * p + p;
+            int qq = 3 * q + q;
+            int pq = 3 * p + q;
+            int qp = 3 * q + p;
+
+            float app = mat[pp];
+            float aqq = mat[qq];
+            float apq = mat[pq];
+
+            float tau = (aqq - app) / (2 * apq);
+            float t = (float) (Math.signum(tau)
+                / (Math.abs(tau) + Math.sqrt(1 + tau * tau)));
+            float c = 1 / (float) Math.sqrt(1 + t * t);
+            float s = t * c;
+
+            for (int k = 0; k < 3; k++)
+            {
+                if (k == p || k == q)
+                {
+                    continue;
+                }
+                int kp = 3 * k + p;
+                int kq = 3 * k + q;
+                int pk = 3 * p + k;
+                int qk = 3 * q + k;
+                float akp = mat[kp];
+                float akq = mat[kq];
+                mat[kp] = c * akp - s * akq;
+                mat[pk] = mat[kp];
+                mat[kq] = s * akp + c * akq;
+                mat[qk] = mat[kq];
+            }
+
+            mat[pp] = c * c * app - 2 * s * c * apq + s * s * aqq;
+            mat[qq] = s * s * app + 2 * s * c * apq + c * c * aqq;
+            mat[pq] = 0;
+            mat[qp] = 0;
+
+            for (int k = 0; k < 3; k++)
+            {
+                int kp = 3 * k + p;
+                int kq = 3 * k + q;
+                float vkp = V[kp];
+                float vkq = V[kq];
+                V[kp] = c * vkp - s * vkq;
+                V[kq] = s * vkp + c * vkq;
+            }
+        }
+        result.eigenvalues[0] = mat[0];
+        result.eigenvalues[1] = mat[4];
+        result.eigenvalues[2] = mat[8];
+    }
+
+    /**
+     * Compute the specified percentile of the given array, IN-PLACE (meaning
+     * that it will sort the given array!)
+     * 
+     * @param xs The array
+     * @param p The percentile
+     * @return The result
+     */
+    static float percentileInPlace(float xs[], float p)
+    {
+        Arrays.parallelSort(xs);
+        if (xs.length == 0)
+        {
+            return 0;
+        }
+        float t = (xs.length - 1) * p;
+        int i = (int) Math.floor(t);
+        int j = Math.min(i + 1, xs.length - 1);
+        float w = t - i;
+        return xs[i] * (1 - w) + xs[j] * w;
+    }
+
+    /**
+     * Private constructor to prevent instantiation
+     */
+    private NanoGsMath()
+    {
+        // Private constructor to prevent instantiation
+    }
+}

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsMath.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsMath.java
@@ -24,14 +24,14 @@ class NanoGsMath
     /**
      * A thread-local 3x3 matrix for "R"
      */
-    private static final ThreadLocal<float[]> THREAD_LOCAL_R =
-        ThreadLocal.withInitial(() -> new float[9]);        
+    private static final ThreadLocal<double[]> THREAD_LOCAL_R =
+        ThreadLocal.withInitial(() -> new double[9]);        
 
     /**
      * A thread-local 3x3 matrix for "matrix"
      */
-    private static final ThreadLocal<float[]> THREAD_LOCAL_matrix =
-        ThreadLocal.withInitial(() -> new float[9]);        
+    private static final ThreadLocal<double[]> THREAD_LOCAL_matrix =
+        ThreadLocal.withInitial(() -> new double[9]);        
 
     /**
      * A container for the results of an eigendecomposition
@@ -41,12 +41,12 @@ class NanoGsMath
         /**
          * The eigenvalues
          */
-        final float[] eigenvalues = new float[3];
+        final double[] eigenvalues = new double[3];
 
         /**
          * The eigenvectors, as a flat 9-element array
          */
-        final float[] eigenvectors = new float[9];
+        final double[] eigenvectors = new double[9];
     }
 
     /**
@@ -55,17 +55,17 @@ class NanoGsMath
      * @param A The input array
      * @return The determinant
      */
-    static float det3Flat(float A[])
+    static double det3Flat(double A[])
     {
-        float a00 = A[0];
-        float a01 = A[1];
-        float a02 = A[2];
-        float a10 = A[3];
-        float a11 = A[4];
-        float a12 = A[5];
-        float a20 = A[6];
-        float a21 = A[7];
-        float a22 = A[8];
+        double a00 = A[0];
+        double a01 = A[1];
+        double a02 = A[2];
+        double a10 = A[3];
+        double a11 = A[4];
+        double a12 = A[5];
+        double a20 = A[6];
+        double a21 = A[7];
+        double a22 = A[8];
         return (a00 * (a11 * a22 - a12 * a21) - a01 * (a10 * a22 - a12 * a20)
             + a02 * (a10 * a21 - a11 * a20));
     }
@@ -77,45 +77,45 @@ class NanoGsMath
      * @param R The array
      * @param q The output
      */
-    static void rotmatToQuatFlat(float R[], float q[])
+    static void rotmatToQuatFlat(double R[], double q[])
     {
-        float m00 = R[0];
-        float m11 = R[4];
-        float m22 = R[8];
-        float tr = m00 + m11 + m22;
-        float qw, qx, qy, qz;
+        double m00 = R[0];
+        double m11 = R[4];
+        double m22 = R[8];
+        double tr = m00 + m11 + m22;
+        double qw, qx, qy, qz;
 
         if (tr > 0)
         {
-            float S = (float) Math.sqrt(tr + 1.0) * 2.0f;
-            qw = 0.25f * S;
+            double S = Math.sqrt(tr + 1.0) * 2.0;
+            qw = 0.25 * S;
             qx = (R[7] - R[5]) / S;
             qy = (R[2] - R[6]) / S;
             qz = (R[3] - R[1]) / S;
         }
         else if (m00 > m11 && m00 > m22)
         {
-            float S = (float) Math.sqrt(1.0 + m00 - m11 - m22) * 2.0f;
+            double S = Math.sqrt(1.0 + m00 - m11 - m22) * 2.0;
             qw = (R[7] - R[5]) / S;
-            qx = 0.25f * S;
+            qx = 0.25 * S;
             qy = (R[1] + R[3]) / S;
             qz = (R[2] + R[6]) / S;
         }
         else if (m11 > m22)
         {
-            float S = (float) Math.sqrt(1.0 + m11 - m00 - m22) * 2.0f;
+            double S = Math.sqrt(1.0 + m11 - m00 - m22) * 2.0;
             qw = (R[2] - R[6]) / S;
             qx = (R[1] + R[3]) / S;
-            qy = 0.25f * S;
+            qy = 0.25 * S;
             qz = (R[5] + R[7]) / S;
         }
         else
         {
-            float S = (float) Math.sqrt(1.0 + m22 - m00 - m11) * 2.0f;
+            double S = Math.sqrt(1.0 + m22 - m00 - m11) * 2.0;
             qw = (R[3] - R[1]) / S;
             qx = (R[2] + R[6]) / S;
             qy = (R[5] + R[7]) / S;
-            qz = 0.25f * S;
+            qz = 0.25 * S;
         }
         q[0] = qw;
         q[1] = qx;
@@ -129,12 +129,12 @@ class NanoGsMath
      * 
      * @param q The quaternion
      */
-    private static void normalize(float[] q)
+    private static void normalize(double[] q)
     {
-        float lenSq = q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3];
+        double lenSq = q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3];
         if (lenSq > 0)
         {
-            float len = (float) Math.sqrt(lenSq);
+            double len = Math.sqrt(lenSq);
             for (int i = 0; i < 4; i++)
             {
                 q[i] /= len;
@@ -152,7 +152,7 @@ class NanoGsMath
      * @param dst The target array
      * @param dOffset The target offset
      */
-    static void transpose3Into(float src[], int sOffset, float dst[],
+    static void transpose3Into(double src[], int sOffset, double dst[],
         int dOffset)
     {
         dst[dOffset + 0] = src[sOffset + 0];
@@ -179,10 +179,10 @@ class NanoGsMath
      * @param sz The scale value along z
      * @param out The output array
      */
-    static void sigmaFromQuatScaleFlatInto(float qw, float qx, float qy,
-        float qz, float sx, float sy, float sz, float[] out)
+    static void sigmaFromQuatScaleFlatInto(double qw, double qx, double qy,
+        double qz, double sx, double sy, double sz, double[] out)
     {
-        float[] R = THREAD_LOCAL_R.get();
+        double[] R = THREAD_LOCAL_R.get();
         quatToRotmatInto(qw, qx, qy, qz, R, 0);
         sigmaFromRotVarInto(R, 0, sx * sx, sy * sy, sz * sz, out, 0);
     }
@@ -198,18 +198,18 @@ class NanoGsMath
      * @param out The output array
      * @param offset The offset
      */
-    static void quatToRotmatInto(float w, float x, float y, float z,
-        float out[], int offset)
+    static void quatToRotmatInto(double w, double x, double y, double z,
+        double out[], int offset)
     {
-        float xx = x * x;
-        float yy = y * y;
-        float zz = z * z;
-        float wx = w * x;
-        float wy = w * y;
-        float wz = w * z;
-        float xy = x * y;
-        float xz = x * z;
-        float yz = y * z;
+        double xx = x * x;
+        double yy = y * y;
+        double zz = z * z;
+        double wx = w * x;
+        double wy = w * y;
+        double wz = w * z;
+        double xy = x * y;
+        double xz = x * z;
+        double yz = y * z;
 
         out[offset + 0] = 1 - 2 * (yy + zz);
         out[offset + 1] = 2 * (xy - wz);
@@ -236,18 +236,18 @@ class NanoGsMath
      * @param out The output array
      * @param oOffset The offset where the output should be written
      */
-    static void sigmaFromRotVarInto(float R[], int rOffset, float vx, float vy,
-        float vz, float out[], int oOffset)
+    static void sigmaFromRotVarInto(double R[], int rOffset, double vx, double vy,
+        double vz, double out[], int oOffset)
     {
-        float r00 = R[rOffset + 0];
-        float r01 = R[rOffset + 1];
-        float r02 = R[rOffset + 2];
-        float r10 = R[rOffset + 3];
-        float r11 = R[rOffset + 4];
-        float r12 = R[rOffset + 5];
-        float r20 = R[rOffset + 6];
-        float r21 = R[rOffset + 7];
-        float r22 = R[rOffset + 8];
+        double r00 = R[rOffset + 0];
+        double r01 = R[rOffset + 1];
+        double r02 = R[rOffset + 2];
+        double r10 = R[rOffset + 3];
+        double r11 = R[rOffset + 4];
+        double r12 = R[rOffset + 5];
+        double r20 = R[rOffset + 6];
+        double r21 = R[rOffset + 7];
+        double r22 = R[rOffset + 8];
 
         out[oOffset + 0] = r00 * r00 * vx + r01 * r01 * vy + r02 * r02 * vz;
         out[oOffset + 1] = r00 * r10 * vx + r01 * r11 * vy + r02 * r12 * vz;
@@ -268,25 +268,25 @@ class NanoGsMath
      * @param matrix The matrix
      * @param result The result
      */
-    static void eigenSymmetric3x3Flat(float[] matrix, Eigendecomposition3x3 result)
+    static void eigenSymmetric3x3Flat(double[] matrix, Eigendecomposition3x3 result)
     {
-        float[] mat = THREAD_LOCAL_matrix.get();
+        double[] mat = THREAD_LOCAL_matrix.get();
         System.arraycopy(matrix, 0, mat, 0, 9);
-        float[] V = result.eigenvectors;
-        V[0] = 1.0f;
-        V[1] = 0.0f;
-        V[2] = 0.0f;
-        V[3] = 0.0f;
-        V[4] = 1.0f;
-        V[5] = 0.0f;
-        V[6] = 0.0f;
-        V[7] = 0.0f;
-        V[8] = 1.0f;
+        double[] V = result.eigenvectors;
+        V[0] = 1.0;
+        V[1] = 0.0;
+        V[2] = 0.0;
+        V[3] = 0.0;
+        V[4] = 1.0;
+        V[5] = 0.0;
+        V[6] = 0.0;
+        V[7] = 0.0;
+        V[8] = 1.0;
         for (int i = 0; i < 24; i++)
         {
             int p = 0;
             int q = 1;
-            float maxAbs = Math.abs(mat[1]);
+            double maxAbs = Math.abs(mat[1]);
 
             if (Math.abs(mat[2]) > maxAbs)
             {
@@ -311,15 +311,15 @@ class NanoGsMath
             int pq = 3 * p + q;
             int qp = 3 * q + p;
 
-            float app = mat[pp];
-            float aqq = mat[qq];
-            float apq = mat[pq];
+            double app = mat[pp];
+            double aqq = mat[qq];
+            double apq = mat[pq];
 
-            float tau = (aqq - app) / (2 * apq);
-            float t = (float) (Math.signum(tau)
+            double tau = (aqq - app) / (2 * apq);
+            double t = (Math.signum(tau)
                 / (Math.abs(tau) + Math.sqrt(1 + tau * tau)));
-            float c = 1 / (float) Math.sqrt(1 + t * t);
-            float s = t * c;
+            double c = 1 / Math.sqrt(1 + t * t);
+            double s = t * c;
 
             for (int k = 0; k < 3; k++)
             {
@@ -331,8 +331,8 @@ class NanoGsMath
                 int kq = 3 * k + q;
                 int pk = 3 * p + k;
                 int qk = 3 * q + k;
-                float akp = mat[kp];
-                float akq = mat[kq];
+                double akp = mat[kp];
+                double akq = mat[kq];
                 mat[kp] = c * akp - s * akq;
                 mat[pk] = mat[kp];
                 mat[kq] = s * akp + c * akq;
@@ -348,8 +348,8 @@ class NanoGsMath
             {
                 int kp = 3 * k + p;
                 int kq = 3 * k + q;
-                float vkp = V[kp];
-                float vkq = V[kq];
+                double vkp = V[kp];
+                double vkq = V[kq];
                 V[kp] = c * vkp - s * vkq;
                 V[kq] = s * vkp + c * vkq;
             }
@@ -367,17 +367,17 @@ class NanoGsMath
      * @param p The percentile
      * @return The result
      */
-    static float percentileInPlace(float xs[], float p)
+    static double percentileInPlace(double xs[], double p)
     {
         Arrays.parallelSort(xs);
         if (xs.length == 0)
         {
             return 0;
         }
-        float t = (xs.length - 1) * p;
+        double t = (xs.length - 1) * p;
         int i = (int) Math.floor(t);
         int j = Math.min(i + 1, xs.length - 1);
-        float w = t - i;
+        double w = t - i;
         return xs[i] * (1 - w) + xs[j] * w;
     }
 

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsMerge.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsMerge.java
@@ -1,0 +1,307 @@
+/*
+ * www.javagl.de - JSplat
+ *
+ * Copyright 2026 Marco Hutter - http://www.javagl.de
+ * 
+ * Ported from https://github.com/saliteta/NanoGS
+ * Commit: 62ddc34e230a01c061b762103ef69113f6259e48
+ *
+ * Published under "Attribution-NonCommercial 4.0 International" license.
+ * See the "NanoGS-LICENSE.txt" in the root directory of this project.
+ */
+package de.javagl.jsplat.simplification.incremental.nanogs;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import de.javagl.jsplat.MutableSplat;
+import de.javagl.jsplat.Splat;
+import de.javagl.jsplat.Splats;
+import de.javagl.jsplat.simplification.incremental.Edge;
+import de.javagl.jsplat.simplification.incremental.nanogs.NanoGsMath.Eigendecomposition3x3;
+
+/**
+ * The merge functionality from NanoGS
+ * 
+ * Ported from https://github.com/saliteta/NanoGS
+ * Commit: 62ddc34e230a01c061b762103ef69113f6259e48
+ */
+class NanoGsMerge
+{
+    /**
+     * Constant for (2*PI)^1.5
+     */
+    private static final float TWO_PI_POW_1P5 =
+        (float) Math.pow(2.0 * Math.PI, 1.5);
+
+    /**
+     * A thread-local 3x3 matrix for "SigI"
+     */
+    private static final ThreadLocal<float[]> THREAD_LOCAL_SigI =
+        ThreadLocal.withInitial(() -> new float[9]);        
+    
+    /**
+     * A thread-local 3x3 matrix for "SigJ"
+     */
+    private static final ThreadLocal<float[]> THREAD_LOCAL_SigJ =
+        ThreadLocal.withInitial(() -> new float[9]);        
+    
+    /**
+     * A thread-local 3x3 matrix for "Sig"
+     */
+    private static final ThreadLocal<float[]> THREAD_LOCAL_Sig =
+        ThreadLocal.withInitial(() -> new float[9]);        
+    
+    /**
+     * A thread-local 3x3 matrix for "R"
+     */
+    private static final ThreadLocal<float[]> THREAD_LOCAL_R =
+        ThreadLocal.withInitial(() -> new float[9]);        
+    
+    /**
+     * A thread-local quaternion "q"
+     */
+    private static final ThreadLocal<float[]> THREAD_LOCAL_q =
+        ThreadLocal.withInitial(() -> new float[4]);        
+    
+    /**
+     * Thread-local indexed values
+     */
+    private static final ThreadLocal<IndexedValue[]> THREAD_LOCAL_indexedValues =
+        ThreadLocal.withInitial(() -> new IndexedValue[] {
+            new IndexedValue(),
+            new IndexedValue(),
+            new IndexedValue(),
+        });        
+
+    /**
+     * Thread-local eigendecomposition
+     */
+    private static final ThreadLocal<Eigendecomposition3x3> THREAD_LOCAL_eigendecomposition =
+        ThreadLocal.withInitial(() -> new Eigendecomposition3x3());        
+    
+    /**
+     * Helper class for sorting eigenvalues
+     */
+    private static class IndexedValue
+    {
+        /**
+         * The value
+         */
+        private float value;
+
+        /**
+         * The index
+         */
+        private int index;
+    }
+
+    /**
+     * Merge the specified pairs of splats, and return a new list containing the
+     * merged ones and the ones that had not been merged from the given list
+     * 
+     * @param cur The input splats
+     * @param pairs THe pairs to merge
+     * @return The result
+     */
+    static List<Splat> mergePairs(List<? extends Splat> cur, List<Edge> pairs)
+    {
+        int N = cur.size();
+        boolean used[] = new boolean[N];
+        int n = pairs.size();
+        List<Splat> list = IntStream.range(0, n).parallel().mapToObj(i ->
+        {
+            Edge pair = pairs.get(i);
+            Splat s0 = cur.get(pair.i0);
+            Splat s1 = cur.get(pair.i1);
+            used[pair.i0] = true;
+            used[pair.i1] = true;
+            MutableSplat m = Splats.copy(s0);
+            NanoGsMerge.merge(s0, s1, m);
+            return m;
+        }).collect(Collectors.toList());
+
+        List<Splat> merged = new ArrayList<Splat>(list);
+        for (int i = 0; i < N; i++)
+        {
+            if (!used[i])
+            {
+                Splat s = cur.get(i);
+                merged.add(s);
+            }
+        }
+        return merged;
+    }
+
+    /**
+     * Merges two Gaussian splats into a third.
+     * 
+     * Ported from https://github.com/RongLiu-Leo/NanoGS/ Commit:
+     * 9e49497b3f16674aed6ab9204584e14794f82f84 Location:
+     * scripts/simplify.js#L646
+     *
+     * @param splatI The first splat.
+     * @param splatJ The second splat.
+     * @param result The splat that will store the result
+     */
+    private static void merge(Splat splatI, Splat splatJ, MutableSplat result)
+    {
+        float scaleIx = (float) Math.exp(splatI.getScaleX());
+        float scaleIy = (float) Math.exp(splatI.getScaleY());
+        float scaleIz = (float) Math.exp(splatI.getScaleZ());
+
+        float scaleJx = (float) Math.exp(splatJ.getScaleX());
+        float scaleJy = (float) Math.exp(splatJ.getScaleY());
+        float scaleJz = (float) Math.exp(splatJ.getScaleZ());
+
+        float rotIw = splatI.getRotationW();
+        float rotIx = splatI.getRotationX();
+        float rotIy = splatI.getRotationY();
+        float rotIz = splatI.getRotationZ();
+
+        float rotJw = splatJ.getRotationW();
+        float rotJx = splatJ.getRotationX();
+        float rotJy = splatJ.getRotationY();
+        float rotJz = splatJ.getRotationZ();
+
+        float alphaI = Splats.opacityToAlpha(splatI.getOpacity());
+        float alphaJ = Splats.opacityToAlpha(splatJ.getOpacity());
+        float scaleI = scaleIx * scaleIy * scaleIz;
+        float scaleJ = scaleJx * scaleJy * scaleJz;
+        float wi = TWO_PI_POW_1P5 * alphaI * scaleI + 1e-12f;
+        float wj = TWO_PI_POW_1P5 * alphaJ * scaleJ + 1e-12f;
+        float W = wi + wj;
+
+        // Compute the weighted average of the positions
+        float muxi = splatI.getPositionX();
+        float muxj = splatJ.getPositionX();
+        float muyi = splatI.getPositionY();
+        float muyj = splatJ.getPositionY();
+        float muzi = splatI.getPositionZ();
+        float muzj = splatJ.getPositionZ();
+        float mux = (wi * muxi + wj * muxj) / W;
+        float muy = (wi * muyi + wj * muyj) / W;
+        float muz = (wi * muzi + wj * muzj) / W;
+
+        // Compute the resulting opacity
+        float alphaBase = alphaI + alphaJ - alphaI * alphaJ;
+        float n_alpha = Math.min(1.0f, Math.max(0.0f, alphaBase));
+        float n_opacity = Splats.alphaToOpacity(n_alpha);
+
+        // Compute the resulting covariance matrix
+        float SigI[] = THREAD_LOCAL_SigI.get();
+        float SigJ[] = THREAD_LOCAL_SigJ.get();
+        NanoGsMath.sigmaFromQuatScaleFlatInto(rotIw, rotIx, rotIy, rotIz,
+            scaleIx, scaleIy, scaleIz, SigI);
+        NanoGsMath.sigmaFromQuatScaleFlatInto(rotJw, rotJx, rotJy, rotJz,
+            scaleJx, scaleIy, scaleJz, SigJ);
+
+        float dix = muxi - mux;
+        float diy = muyi - muy;
+        float diz = muzi - muz;
+
+        float djx = muxj - mux;
+        float djy = muyj - muy;
+        float djz = muzj - muz;
+
+        float Sig[] = THREAD_LOCAL_Sig.get();
+        for (int a = 0; a < 9; a++)
+        {
+            Sig[a] = (wi * SigI[a] + wj * SigJ[a]) / W;
+        }
+
+        Sig[0] += (wi * dix * dix + wj * djx * djx) / W;
+        Sig[1] += (wi * dix * diy + wj * djx * djy) / W;
+        Sig[2] += (wi * dix * diz + wj * djx * djz) / W;
+        Sig[3] += (wi * diy * dix + wj * djy * djx) / W;
+        Sig[4] += (wi * diy * diy + wj * djy * djy) / W;
+        Sig[5] += (wi * diy * diz + wj * djy * djz) / W;
+        Sig[6] += (wi * diz * dix + wj * djz * djx) / W;
+        Sig[7] += (wi * diz * diy + wj * djz * djy) / W;
+        Sig[8] += (wi * diz * diz + wj * djz * djz) / W;
+
+        float s01 = 0.5f * (Sig[1] + Sig[3]);
+        float s02 = 0.5f * (Sig[2] + Sig[6]);
+        float s12 = 0.5f * (Sig[5] + Sig[7]);
+        Sig[1] = Sig[3] = s01;
+        Sig[2] = Sig[6] = s02;
+        Sig[5] = Sig[7] = s12;
+        Sig[0] += 1e-8;
+        Sig[4] += 1e-8;
+        Sig[8] += 1e-8;
+
+        // Extract the scale (eigenvalues) and rotation from the eigenvectors
+        Eigendecomposition3x3 ev = THREAD_LOCAL_eigendecomposition.get();
+        NanoGsMath.eigenSymmetric3x3Flat(Sig, ev);
+        float[] vals = ev.eigenvalues;
+        float[] vecs = ev.eigenvectors;
+
+        IndexedValue[] indexedEigenvalues = THREAD_LOCAL_indexedValues.get();
+        indexedEigenvalues[0].index = 0;
+        indexedEigenvalues[0].value = vals[0];
+        indexedEigenvalues[1].index = 1;
+        indexedEigenvalues[1].value = vals[1];
+        indexedEigenvalues[2].index = 2;
+        indexedEigenvalues[2].value = vals[2];
+        Arrays.sort(indexedEigenvalues,
+            Comparator.comparingDouble(v -> v.value));
+        vals[0] = indexedEigenvalues[0].value;
+        vals[1] = indexedEigenvalues[1].value;
+        vals[2] = indexedEigenvalues[2].value;
+
+        float R[] = THREAD_LOCAL_R.get();
+        for (int c = 0; c < 3; c++)
+        {
+            int src = indexedEigenvalues[c].index;
+            R[0 + c] = vecs[0 + src];
+            R[3 + c] = vecs[3 + src];
+            R[6 + c] = vecs[6 + src];
+        }
+
+        if (NanoGsMath.det3Flat(R) < 0)
+        {
+            R[2] = -R[2];
+            R[5] = -R[5];
+            R[8] = -R[8];
+        }
+
+        float q[] = THREAD_LOCAL_q.get();
+        NanoGsMath.rotmatToQuatFlat(R, q);
+
+        // Assign the computed properties to the result splat
+        result.setPositionX(mux);
+        result.setPositionY(muy);
+        result.setPositionZ(muz);
+        result.setScaleX((float) Math.log(Math.sqrt(vals[0])));
+        result.setScaleY((float) Math.log(Math.sqrt(vals[1])));
+        result.setScaleZ((float) Math.log(Math.sqrt(vals[2])));
+        result.setRotationW(q[0]);
+        result.setRotationX(q[1]);
+        result.setRotationY(q[2]);
+        result.setRotationZ(q[3]);
+        result.setOpacity(n_opacity);
+        
+        // Compute the weighted average of the spherical harmonics coefficients
+        int dim = splatI.getShDimensions();
+        for (int i = 0; i < dim; i++)
+        {
+            float shXi = splatI.getShX(i);
+            float shXj = splatJ.getShX(i);
+            float shYi = splatI.getShY(i);
+            float shYj = splatJ.getShY(i);
+            float shZi = splatI.getShZ(i);
+            float shZj = splatJ.getShZ(i);
+            float shX = (wi * shXi + wj * shXj) / W;
+            float shY = (wi * shYi + wj * shYj) / W;
+            float shZ = (wi * shZi + wj * shZj) / W;
+            result.setShX(i, shX);
+            result.setShY(i, shY);
+            result.setShZ(i, shZ);
+        }
+    }
+
+}

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsMerge.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsMerge.java
@@ -35,38 +35,38 @@ class NanoGsMerge
     /**
      * Constant for (2*PI)^1.5
      */
-    private static final float TWO_PI_POW_1P5 =
-        (float) Math.pow(2.0 * Math.PI, 1.5);
+    private static final double TWO_PI_POW_1P5 =
+        Math.pow(2.0 * Math.PI, 1.5);
 
     /**
      * A thread-local 3x3 matrix for "SigI"
      */
-    private static final ThreadLocal<float[]> THREAD_LOCAL_SigI =
-        ThreadLocal.withInitial(() -> new float[9]);        
+    private static final ThreadLocal<double[]> THREAD_LOCAL_SigI =
+        ThreadLocal.withInitial(() -> new double[9]);        
     
     /**
      * A thread-local 3x3 matrix for "SigJ"
      */
-    private static final ThreadLocal<float[]> THREAD_LOCAL_SigJ =
-        ThreadLocal.withInitial(() -> new float[9]);        
+    private static final ThreadLocal<double[]> THREAD_LOCAL_SigJ =
+        ThreadLocal.withInitial(() -> new double[9]);        
     
     /**
      * A thread-local 3x3 matrix for "Sig"
      */
-    private static final ThreadLocal<float[]> THREAD_LOCAL_Sig =
-        ThreadLocal.withInitial(() -> new float[9]);        
+    private static final ThreadLocal<double[]> THREAD_LOCAL_Sig =
+        ThreadLocal.withInitial(() -> new double[9]);        
     
     /**
      * A thread-local 3x3 matrix for "R"
      */
-    private static final ThreadLocal<float[]> THREAD_LOCAL_R =
-        ThreadLocal.withInitial(() -> new float[9]);        
+    private static final ThreadLocal<double[]> THREAD_LOCAL_R =
+        ThreadLocal.withInitial(() -> new double[9]);        
     
     /**
      * A thread-local quaternion "q"
      */
-    private static final ThreadLocal<float[]> THREAD_LOCAL_q =
-        ThreadLocal.withInitial(() -> new float[4]);        
+    private static final ThreadLocal<double[]> THREAD_LOCAL_q =
+        ThreadLocal.withInitial(() -> new double[4]);        
     
     /**
      * Thread-local indexed values
@@ -92,7 +92,7 @@ class NanoGsMerge
         /**
          * The value
          */
-        private float value;
+        private double value;
 
         /**
          * The index
@@ -150,65 +150,65 @@ class NanoGsMerge
      */
     private static void merge(Splat splatI, Splat splatJ, MutableSplat result)
     {
-        float scaleIx = (float) Math.exp(splatI.getScaleX());
-        float scaleIy = (float) Math.exp(splatI.getScaleY());
-        float scaleIz = (float) Math.exp(splatI.getScaleZ());
+        double scaleIx = Math.exp(splatI.getScaleX());
+        double scaleIy = Math.exp(splatI.getScaleY());
+        double scaleIz = Math.exp(splatI.getScaleZ());
 
-        float scaleJx = (float) Math.exp(splatJ.getScaleX());
-        float scaleJy = (float) Math.exp(splatJ.getScaleY());
-        float scaleJz = (float) Math.exp(splatJ.getScaleZ());
+        double scaleJx = Math.exp(splatJ.getScaleX());
+        double scaleJy = Math.exp(splatJ.getScaleY());
+        double scaleJz = Math.exp(splatJ.getScaleZ());
 
-        float rotIw = splatI.getRotationW();
-        float rotIx = splatI.getRotationX();
-        float rotIy = splatI.getRotationY();
-        float rotIz = splatI.getRotationZ();
+        double rotIw = splatI.getRotationW();
+        double rotIx = splatI.getRotationX();
+        double rotIy = splatI.getRotationY();
+        double rotIz = splatI.getRotationZ();
 
-        float rotJw = splatJ.getRotationW();
-        float rotJx = splatJ.getRotationX();
-        float rotJy = splatJ.getRotationY();
-        float rotJz = splatJ.getRotationZ();
+        double rotJw = splatJ.getRotationW();
+        double rotJx = splatJ.getRotationX();
+        double rotJy = splatJ.getRotationY();
+        double rotJz = splatJ.getRotationZ();
 
-        float alphaI = Splats.opacityToAlpha(splatI.getOpacity());
-        float alphaJ = Splats.opacityToAlpha(splatJ.getOpacity());
-        float scaleI = scaleIx * scaleIy * scaleIz;
-        float scaleJ = scaleJx * scaleJy * scaleJz;
-        float wi = TWO_PI_POW_1P5 * alphaI * scaleI + 1e-12f;
-        float wj = TWO_PI_POW_1P5 * alphaJ * scaleJ + 1e-12f;
-        float W = wi + wj;
+        double alphaI = Splats.opacityToAlpha(splatI.getOpacity());
+        double alphaJ = Splats.opacityToAlpha(splatJ.getOpacity());
+        double scaleI = scaleIx * scaleIy * scaleIz;
+        double scaleJ = scaleJx * scaleJy * scaleJz;
+        double wi = TWO_PI_POW_1P5 * alphaI * scaleI + 1e-12;
+        double wj = TWO_PI_POW_1P5 * alphaJ * scaleJ + 1e-12;
+        double W = wi + wj;
 
         // Compute the weighted average of the positions
-        float muxi = splatI.getPositionX();
-        float muxj = splatJ.getPositionX();
-        float muyi = splatI.getPositionY();
-        float muyj = splatJ.getPositionY();
-        float muzi = splatI.getPositionZ();
-        float muzj = splatJ.getPositionZ();
-        float mux = (wi * muxi + wj * muxj) / W;
-        float muy = (wi * muyi + wj * muyj) / W;
-        float muz = (wi * muzi + wj * muzj) / W;
+        double muxi = splatI.getPositionX();
+        double muxj = splatJ.getPositionX();
+        double muyi = splatI.getPositionY();
+        double muyj = splatJ.getPositionY();
+        double muzi = splatI.getPositionZ();
+        double muzj = splatJ.getPositionZ();
+        double mux = (wi * muxi + wj * muxj) / W;
+        double muy = (wi * muyi + wj * muyj) / W;
+        double muz = (wi * muzi + wj * muzj) / W;
 
         // Compute the resulting opacity
-        float alphaBase = alphaI + alphaJ - alphaI * alphaJ;
-        float n_alpha = Math.min(1.0f, Math.max(0.0f, alphaBase));
-        float n_opacity = Splats.alphaToOpacity(n_alpha);
+        double alphaBase = alphaI + alphaJ - alphaI * alphaJ;
+        double n_alpha = Math.min(1.0f, Math.max(0.0f, alphaBase));
+        double n_opacity = Splats.alphaToOpacity(n_alpha);
 
         // Compute the resulting covariance matrix
-        float SigI[] = THREAD_LOCAL_SigI.get();
-        float SigJ[] = THREAD_LOCAL_SigJ.get();
+        double SigI[] = THREAD_LOCAL_SigI.get();
+        double SigJ[] = THREAD_LOCAL_SigJ.get();
         NanoGsMath.sigmaFromQuatScaleFlatInto(rotIw, rotIx, rotIy, rotIz,
             scaleIx, scaleIy, scaleIz, SigI);
         NanoGsMath.sigmaFromQuatScaleFlatInto(rotJw, rotJx, rotJy, rotJz,
             scaleJx, scaleIy, scaleJz, SigJ);
 
-        float dix = muxi - mux;
-        float diy = muyi - muy;
-        float diz = muzi - muz;
+        double dix = muxi - mux;
+        double diy = muyi - muy;
+        double diz = muzi - muz;
 
-        float djx = muxj - mux;
-        float djy = muyj - muy;
-        float djz = muzj - muz;
+        double djx = muxj - mux;
+        double djy = muyj - muy;
+        double djz = muzj - muz;
 
-        float Sig[] = THREAD_LOCAL_Sig.get();
+        double Sig[] = THREAD_LOCAL_Sig.get();
         for (int a = 0; a < 9; a++)
         {
             Sig[a] = (wi * SigI[a] + wj * SigJ[a]) / W;
@@ -224,9 +224,9 @@ class NanoGsMerge
         Sig[7] += (wi * diz * diy + wj * djz * djy) / W;
         Sig[8] += (wi * diz * diz + wj * djz * djz) / W;
 
-        float s01 = 0.5f * (Sig[1] + Sig[3]);
-        float s02 = 0.5f * (Sig[2] + Sig[6]);
-        float s12 = 0.5f * (Sig[5] + Sig[7]);
+        double s01 = 0.5 * (Sig[1] + Sig[3]);
+        double s02 = 0.5 * (Sig[2] + Sig[6]);
+        double s12 = 0.5 * (Sig[5] + Sig[7]);
         Sig[1] = Sig[3] = s01;
         Sig[2] = Sig[6] = s02;
         Sig[5] = Sig[7] = s12;
@@ -237,8 +237,8 @@ class NanoGsMerge
         // Extract the scale (eigenvalues) and rotation from the eigenvectors
         Eigendecomposition3x3 ev = THREAD_LOCAL_eigendecomposition.get();
         NanoGsMath.eigenSymmetric3x3Flat(Sig, ev);
-        float[] vals = ev.eigenvalues;
-        float[] vecs = ev.eigenvectors;
+        double[] vals = ev.eigenvalues;
+        double[] vecs = ev.eigenvectors;
 
         IndexedValue[] indexedEigenvalues = THREAD_LOCAL_indexedValues.get();
         indexedEigenvalues[0].index = 0;
@@ -253,7 +253,7 @@ class NanoGsMerge
         vals[1] = indexedEigenvalues[1].value;
         vals[2] = indexedEigenvalues[2].value;
 
-        float R[] = THREAD_LOCAL_R.get();
+        double R[] = THREAD_LOCAL_R.get();
         for (int c = 0; c < 3; c++)
         {
             int src = indexedEigenvalues[c].index;
@@ -269,16 +269,16 @@ class NanoGsMerge
             R[8] = -R[8];
         }
 
-        float q[] = THREAD_LOCAL_q.get();
+        double q[] = THREAD_LOCAL_q.get();
         NanoGsMath.rotmatToQuatFlat(R, q);
 
         // Assign the computed properties to the result splat
         result.setPositionX(mux);
         result.setPositionY(muy);
         result.setPositionZ(muz);
-        result.setScaleX((float) Math.log(Math.sqrt(vals[0])));
-        result.setScaleY((float) Math.log(Math.sqrt(vals[1])));
-        result.setScaleZ((float) Math.log(Math.sqrt(vals[2])));
+        result.setScaleX(Math.log(Math.sqrt(vals[0])));
+        result.setScaleY(Math.log(Math.sqrt(vals[1])));
+        result.setScaleZ(Math.log(Math.sqrt(vals[2])));
         result.setRotationW(q[0]);
         result.setRotationX(q[1]);
         result.setRotationY(q[2]);
@@ -289,15 +289,15 @@ class NanoGsMerge
         int dim = splatI.getShDimensions();
         for (int i = 0; i < dim; i++)
         {
-            float shXi = splatI.getShX(i);
-            float shXj = splatJ.getShX(i);
-            float shYi = splatI.getShY(i);
-            float shYj = splatJ.getShY(i);
-            float shZi = splatI.getShZ(i);
-            float shZj = splatJ.getShZ(i);
-            float shX = (wi * shXi + wj * shXj) / W;
-            float shY = (wi * shYi + wj * shYj) / W;
-            float shZ = (wi * shZi + wj * shZj) / W;
+            double shXi = splatI.getShX(i);
+            double shXj = splatJ.getShX(i);
+            double shYi = splatI.getShY(i);
+            double shYj = splatJ.getShY(i);
+            double shZi = splatI.getShZ(i);
+            double shZj = splatJ.getShZ(i);
+            double shX = (wi * shXi + wj * shXj) / W;
+            double shY = (wi * shYi + wj * shYj) / W;
+            double shZ = (wi * shZi + wj * shZj) / W;
             result.setShX(i, shX);
             result.setShY(i, shY);
             result.setShZ(i, shZ);

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsPruning.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsPruning.java
@@ -1,0 +1,75 @@
+/*
+ * www.javagl.de - JSplat
+ *
+ * Copyright 2026 Marco Hutter - http://www.javagl.de
+ * 
+ * Ported from https://github.com/saliteta/NanoGS
+ * Commit: 62ddc34e230a01c061b762103ef69113f6259e48
+ *
+ * Published under "Attribution-NonCommercial 4.0 International" license.
+ * See the "NanoGS-LICENSE.txt" in the root directory of this project.
+ */
+package de.javagl.jsplat.simplification.incremental.nanogs;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import de.javagl.jsplat.Splat;
+import de.javagl.jsplat.Splats;
+
+/**
+ * Methods for the opacity-based pruning of NanoGS
+ * 
+ * Ported from https://github.com/saliteta/NanoGS
+ * Commit: 62ddc34e230a01c061b762103ef69113f6259e48
+ */
+class NanoGsPruning
+{
+    /**
+     * Prune the given list by the given opacity threshold.
+     * 
+     * The threshold is referring to an ALPHA value in [0,1].
+     * 
+     * Location: scripts/simplify.js#L305
+     * 
+     * @param state The state
+     * @param threshold The threshold
+     * @return The pruned list
+     */
+    static List<Splat> pruneByOpacity(List<Splat> state,
+        float threshold)
+    {
+        int N = state.size();
+        if (N == 0)
+        {
+            return state;
+        }
+        float ops[] = new float[N];
+        IntStream.range(0, N).parallel().forEach(i ->
+        {
+            float vo = state.get(i).getOpacity();
+            float v = Splats.opacityToAlpha(vo);
+            ops[i] = v;
+        });
+        float median = NanoGsMath.percentileInPlace(ops, 0.5f);
+        float thr = Math.min(threshold, median);
+        List<Splat> keep = state.stream().parallel().filter(s -> 
+        {
+            float vo = s.getOpacity();
+            float v = Splats.opacityToAlpha(vo);
+            return v >= thr;            
+        }).collect(Collectors.toList());
+        return keep;
+    }
+    
+    /**
+     * Private constructor to prevent instantiation
+     */
+    private NanoGsPruning()
+    {
+        // Private constructor to prevent instantiation
+    }
+    
+
+}

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsPruning.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsPruning.java
@@ -38,26 +38,26 @@ class NanoGsPruning
      * @return The pruned list
      */
     static List<Splat> pruneByOpacity(List<Splat> state,
-        float threshold)
+        double threshold)
     {
         int N = state.size();
         if (N == 0)
         {
             return state;
         }
-        float ops[] = new float[N];
+        double ops[] = new double[N];
         IntStream.range(0, N).parallel().forEach(i ->
         {
-            float vo = state.get(i).getOpacity();
-            float v = Splats.opacityToAlpha(vo);
+            double vo = state.get(i).getOpacity();
+            double v = Splats.opacityToAlpha(vo);
             ops[i] = v;
         });
-        float median = NanoGsMath.percentileInPlace(ops, 0.5f);
-        float thr = Math.min(threshold, median);
+        double median = NanoGsMath.percentileInPlace(ops, 0.5);
+        double thr = Math.min(threshold, median);
         List<Splat> keep = state.stream().parallel().filter(s -> 
         {
-            float vo = s.getOpacity();
-            float v = Splats.opacityToAlpha(vo);
+            double vo = s.getOpacity();
+            double v = Splats.opacityToAlpha(vo);
             return v >= thr;            
         }).collect(Collectors.toList());
         return keep;

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsSampling.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsSampling.java
@@ -1,0 +1,68 @@
+/*
+ * www.javagl.de - JSplat
+ *
+ * Copyright 2026 Marco Hutter - http://www.javagl.de
+ * 
+ * Ported from https://github.com/saliteta/NanoGS
+ * Commit: 62ddc34e230a01c061b762103ef69113f6259e48
+ * 
+ * Published under "Attribution-NonCommercial 4.0 International" license.
+ * See the "NanoGS-LICENSE.txt" in the root directory of this project.
+ */
+package de.javagl.jsplat.simplification.incremental.nanogs;
+
+import java.util.Random;
+import java.util.stream.IntStream;
+
+/**
+ * Utility methods for the sampling in NanoGS.
+ * 
+ * Ported from https://github.com/saliteta/NanoGS
+ * Commit: 62ddc34e230a01c061b762103ef69113f6259e48
+ */
+class NanoGsSampling
+{
+    /**
+     * Computes the specified number of 3D sample points, following a Gaussian
+     * distribution.
+     * 
+     * Location: scripts/simplify.js#L1199
+     * 
+     * @param n The number of sample points
+     * @param seed The random seet
+     * @return The points, as an array of 3-element arrays
+     */
+    static float[][] makeGaussianSamples(int n, int seed)
+    {
+        Random rand = new Random(seed);
+        float out[][] = new float[n][];
+        IntStream.range(0, n).parallel().forEach(i ->
+        {
+            float u1 = Math.max(rand.nextFloat(), 1e-12f);
+            float u2 = rand.nextFloat();
+            float u3 = Math.max(rand.nextFloat(), 1e-12f);
+            float u4 = rand.nextFloat();
+
+            float r1 = (float) (Math.sqrt(-2.0 * Math.log(u1)));
+            float t1 = (float) (2.0 * Math.PI * u2);
+            float r2 = (float) (Math.sqrt(-2.0 * Math.log(u3)));
+            float t2 = (float) (2.0 * Math.PI * u4);
+
+            float x = (float) (r1 * Math.cos(t1));
+            float y = (float) (r1 * Math.sin(t1));
+            float z = (float) (r2 * Math.cos(t2));
+            out[i] = new float[]
+            { x, y, z, };
+        });
+        return out;
+    }
+
+    /**
+     * Private constructor to prevent instantiation
+     */
+    private NanoGsSampling()
+    {
+        // Private constructor to prevent instantiation
+    }
+
+}

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsSampling.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/NanoGsSampling.java
@@ -32,26 +32,26 @@ class NanoGsSampling
      * @param seed The random seet
      * @return The points, as an array of 3-element arrays
      */
-    static float[][] makeGaussianSamples(int n, int seed)
+    static double[][] makeGaussianSamples(int n, int seed)
     {
         Random rand = new Random(seed);
-        float out[][] = new float[n][];
+        double out[][] = new double[n][];
         IntStream.range(0, n).parallel().forEach(i ->
         {
-            float u1 = Math.max(rand.nextFloat(), 1e-12f);
-            float u2 = rand.nextFloat();
-            float u3 = Math.max(rand.nextFloat(), 1e-12f);
-            float u4 = rand.nextFloat();
+            double u1 = Math.max(rand.nextDouble(), 1e-12);
+            double u2 = rand.nextDouble();
+            double u3 = Math.max(rand.nextDouble(), 1e-12);
+            double u4 = rand.nextDouble();
 
-            float r1 = (float) (Math.sqrt(-2.0 * Math.log(u1)));
-            float t1 = (float) (2.0 * Math.PI * u2);
-            float r2 = (float) (Math.sqrt(-2.0 * Math.log(u3)));
-            float t2 = (float) (2.0 * Math.PI * u4);
+            double r1 = Math.sqrt(-2.0 * Math.log(u1));
+            double t1 = 2.0 * Math.PI * u2;
+            double r2 = Math.sqrt(-2.0 * Math.log(u3));
+            double t2 = 2.0 * Math.PI * u4;
 
-            float x = (float) (r1 * Math.cos(t1));
-            float y = (float) (r1 * Math.sin(t1));
-            float z = (float) (r2 * Math.cos(t2));
-            out[i] = new float[]
+            double x = r1 * Math.cos(t1);
+            double y = r1 * Math.sin(t1);
+            double z = r2 * Math.cos(t2);
+            out[i] = new double[]
             { x, y, z, };
         });
         return out;

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/package-info.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/nanogs/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Classes for simplifying Gaussian splat data sets using NanoGS.
+ * 
+ * These classes are not part of the public API.
+ * 
+ * Ported from https://github.com/saliteta/NanoGS
+ * Commit: 62ddc34e230a01c061b762103ef69113f6259e48
+ */
+package de.javagl.jsplat.simplification.incremental.nanogs;

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/package-info.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/incremental/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Classes for incrementally simplifying Gaussian splat data sets.
+ * 
+ * These classes are not part of the public API.
+ */
+package de.javagl.jsplat.simplification.incremental;

--- a/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/package-info.java
+++ b/jsplat-simplification/src/main/java/de/javagl/jsplat/simplification/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Classes for simplifying Gaussian splat data sets
+ */
+package de.javagl.jsplat.simplification;

--- a/jsplat-viewer-lwjgl/src/main/java/de/javagl/jsplat/viewer/lwjgl/BasicSplatSorter.java
+++ b/jsplat-viewer-lwjgl/src/main/java/de/javagl/jsplat/viewer/lwjgl/BasicSplatSorter.java
@@ -162,9 +162,9 @@ class BasicSplatSorter implements SplatSorter
         for (int i = 0; i < numSplats; i++)
         {
             Splat s = splats.get(i);
-            float px = s.getPositionX();
-            float py = s.getPositionY();
-            float pz = s.getPositionZ();
+            float px = (float)s.getPositionX();
+            float py = (float)s.getPositionY();
+            float pz = (float)s.getPositionZ();
             float depth = mx * px + my * py + mz * pz + mw;
             DepthEntry depthEntry = depthEntries[i];
             depthEntry.index = i;

--- a/jsplat-viewer-lwjgl/src/main/java/de/javagl/jsplat/viewer/lwjgl/SplatData.java
+++ b/jsplat-viewer-lwjgl/src/main/java/de/javagl/jsplat/viewer/lwjgl/SplatData.java
@@ -359,20 +359,20 @@ class SplatData
         {
             int j = i * stride;
             Splat s = splats.get(i);
-            gaussianData.put(j++, s.getPositionX());
-            gaussianData.put(j++, s.getPositionY());
-            gaussianData.put(j++, s.getPositionZ());
+            gaussianData.put(j++, (float)s.getPositionX());
+            gaussianData.put(j++, (float)s.getPositionY());
+            gaussianData.put(j++, (float)s.getPositionZ());
 
-            gaussianData.put(j++, s.getRotationW());
-            gaussianData.put(j++, s.getRotationX());
-            gaussianData.put(j++, s.getRotationY());
-            gaussianData.put(j++, s.getRotationZ());
+            gaussianData.put(j++, (float)s.getRotationW());
+            gaussianData.put(j++, (float)s.getRotationX());
+            gaussianData.put(j++, (float)s.getRotationY());
+            gaussianData.put(j++, (float)s.getRotationZ());
 
             gaussianData.put(j++, (float) Math.exp(s.getScaleX()));
             gaussianData.put(j++, (float) Math.exp(s.getScaleY()));
             gaussianData.put(j++, (float) Math.exp(s.getScaleZ()));
 
-            gaussianData.put(j++, Splats.opacityToAlpha(s.getOpacity()));
+            gaussianData.put(j++, (float)Splats.opacityToAlpha(s.getOpacity()));
 
             for (int d = 0; d < shDimensions; d++)
             {
@@ -381,9 +381,9 @@ class SplatData
                 float shZ = 0.0f;
                 if (d < s.getShDimensions())
                 {
-                    shX = s.getShX(d);
-                    shY = s.getShY(d);
-                    shZ = s.getShZ(d);
+                    shX = (float)s.getShX(d);
+                    shY = (float)s.getShY(d);
+                    shZ = (float)s.getShZ(d);
                 }
                 gaussianData.put(j++, shX);
                 gaussianData.put(j++, shY);

--- a/jsplat-viewer/src/main/java/de/javagl/jsplat/viewer/AbstractSplatViewer.java
+++ b/jsplat-viewer/src/main/java/de/javagl/jsplat/viewer/AbstractSplatViewer.java
@@ -108,12 +108,12 @@ public abstract class AbstractSplatViewer implements SplatViewer
             Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY };
         for (Splat s : splats)
         {
-            minMax[0] = Math.min(minMax[0], s.getPositionX());
-            minMax[1] = Math.min(minMax[1], s.getPositionY());
-            minMax[2] = Math.min(minMax[2], s.getPositionZ());
-            minMax[3] = Math.max(minMax[3], s.getPositionX());
-            minMax[4] = Math.max(minMax[4], s.getPositionY());
-            minMax[5] = Math.max(minMax[5], s.getPositionZ());
+            minMax[0] = (float)Math.min(minMax[0], s.getPositionX());
+            minMax[1] = (float)Math.min(minMax[1], s.getPositionY());
+            minMax[2] = (float)Math.min(minMax[2], s.getPositionZ());
+            minMax[3] = (float)Math.max(minMax[3], s.getPositionX());
+            minMax[4] = (float)Math.max(minMax[4], s.getPositionY());
+            minMax[5] = (float)Math.max(minMax[5], s.getPositionZ());
         }
         renderingCamera.fit(minMax);
     }

--- a/jsplat/src/main/java/de/javagl/jsplat/DefaultSplat.java
+++ b/jsplat/src/main/java/de/javagl/jsplat/DefaultSplat.java
@@ -44,7 +44,7 @@ class DefaultSplat implements MutableSplat
     /**
      * The actual data
      */
-    private float data[];
+    private double data[];
 
     /**
      * Creates a new instance
@@ -62,7 +62,7 @@ class DefaultSplat implements MutableSplat
         }
         this.shDegree = shDegree;
         this.shDimensions = Splats.dimensionsForDegree(shDegree);
-        this.data = new float[3 + 3 + 4 + 1 + shDimensions * 3];
+        this.data = new double[3 + 3 + 4 + 1 + shDimensions * 3];
     }
 
     @Override
@@ -78,169 +78,169 @@ class DefaultSplat implements MutableSplat
     }
 
     @Override
-    public float getPositionX()
+    public double getPositionX()
     {
         return data[0];
     }
 
     @Override
-    public float getPositionY()
+    public double getPositionY()
     {
         return data[1];
     }
 
     @Override
-    public float getPositionZ()
+    public double getPositionZ()
     {
         return data[2];
     }
 
     @Override
-    public float getScaleX()
+    public double getScaleX()
     {
         return data[3];
     }
 
     @Override
-    public float getScaleY()
+    public double getScaleY()
     {
         return data[4];
     }
 
     @Override
-    public float getScaleZ()
+    public double getScaleZ()
     {
         return data[5];
     }
 
     @Override
-    public float getRotationX()
+    public double getRotationX()
     {
         return data[6];
     }
 
     @Override
-    public float getRotationY()
+    public double getRotationY()
     {
         return data[7];
     }
 
     @Override
-    public float getRotationZ()
+    public double getRotationZ()
     {
         return data[8];
     }
 
     @Override
-    public float getRotationW()
+    public double getRotationW()
     {
         return data[9];
     }
 
     @Override
-    public float getOpacity()
+    public double getOpacity()
     {
         return data[10];
     }
 
     @Override
-    public float getShX(int dimension)
+    public double getShX(int dimension)
     {
         return data[11 + dimension * 3 + 0];
     }
 
     @Override
-    public float getShY(int dimension)
+    public double getShY(int dimension)
     {
         return data[11 + dimension * 3 + 1];
     }
 
     @Override
-    public float getShZ(int dimension)
+    public double getShZ(int dimension)
     {
         return data[11 + dimension * 3 + 2];
     }
 
     @Override
-    public void setPositionX(float v)
+    public void setPositionX(double v)
     {
         data[0] = v;
     }
 
     @Override
-    public void setPositionY(float v)
+    public void setPositionY(double v)
     {
         data[1] = v;
     }
 
     @Override
-    public void setPositionZ(float v)
+    public void setPositionZ(double v)
     {
         data[2] = v;
     }
 
     @Override
-    public void setScaleX(float v)
+    public void setScaleX(double v)
     {
         data[3] = v;
     }
 
     @Override
-    public void setScaleY(float v)
+    public void setScaleY(double v)
     {
         data[4] = v;
     }
 
     @Override
-    public void setScaleZ(float v)
+    public void setScaleZ(double v)
     {
         data[5] = v;
     }
 
     @Override
-    public void setRotationX(float v)
+    public void setRotationX(double v)
     {
         data[6] = v;
     }
 
     @Override
-    public void setRotationY(float v)
+    public void setRotationY(double v)
     {
         data[7] = v;
     }
 
     @Override
-    public void setRotationZ(float v)
+    public void setRotationZ(double v)
     {
         data[8] = v;
     }
 
     @Override
-    public void setRotationW(float v)
+    public void setRotationW(double v)
     {
         data[9] = v;
     }
 
     @Override
-    public void setOpacity(float v)
+    public void setOpacity(double v)
     {
         data[10] = v;
     }
 
     @Override
-    public void setShX(int dimension, float v)
+    public void setShX(int dimension, double v)
     {
         data[11 + dimension * 3 + 0] = v;
     }
 
     @Override
-    public void setShY(int dimension, float v)
+    public void setShY(int dimension, double v)
     {
         data[11 + dimension * 3 + 1] = v;
     }
 
     @Override
-    public void setShZ(int dimension, float v)
+    public void setShZ(int dimension, double v)
     {
         data[11 + dimension * 3 + 2] = v;
     }

--- a/jsplat/src/main/java/de/javagl/jsplat/MutableSplat.java
+++ b/jsplat/src/main/java/de/javagl/jsplat/MutableSplat.java
@@ -36,77 +36,77 @@ public interface MutableSplat extends Splat
      * 
      * @param v The value
      */
-    void setPositionX(float v);
+    void setPositionX(double v);
 
     /**
      * Set the y-coordinate of the position
      * 
      * @param v The value
      */
-    void setPositionY(float v);
+    void setPositionY(double v);
 
     /**
      * Set the z-coordinate of the position
      * 
      * @param v The value
      */
-    void setPositionZ(float v);
+    void setPositionZ(double v);
 
     /**
      * Set scale factor in x-direction
      * 
      * @param v The value
      */
-    void setScaleX(float v);
+    void setScaleX(double v);
 
     /**
      * Set scale factor in y-direction
      * 
      * @param v The value
      */
-    void setScaleY(float v);
+    void setScaleY(double v);
 
     /**
      * Set scale factor in y-direction
      * 
      * @param v The value
      */
-    void setScaleZ(float v);
+    void setScaleZ(double v);
 
     /**
      * Set the x-component of the rotation quaternion
      * 
      * @param v The value
      */
-    void setRotationX(float v);
+    void setRotationX(double v);
 
     /**
      * Set the y-component of the rotation quaternion
      * 
      * @param v The value
      */
-    void setRotationY(float v);
+    void setRotationY(double v);
 
     /**
      * Set the z-component of the rotation quaternion
      * 
      * @param v The value
      */
-    void setRotationZ(float v);
+    void setRotationZ(double v);
 
     /**
      * Set the w-component of the rotation quaternion
      * 
      * @param v The value
      */
-    void setRotationW(float v);
+    void setRotationW(double v);
 
     /**
      * Set the opacity value
      * 
      * @param v The value
      */
-    void setOpacity(float v);
+    void setOpacity(double v);
 
     /**
      * Set the x-component of the spherical harmonic for the given dimension
@@ -114,7 +114,7 @@ public interface MutableSplat extends Splat
      * @param dimension The dimension
      * @param v The value
      */
-    void setShX(int dimension, float v);
+    void setShX(int dimension, double v);
 
     /**
      * Set the y-component of the spherical harmonic for the given dimension
@@ -122,7 +122,7 @@ public interface MutableSplat extends Splat
      * @param dimension The dimension
      * @param v The value
      */
-    void setShY(int dimension, float v);
+    void setShY(int dimension, double v);
 
     /**
      * Set the z-component of the spherical harmonic for the given dimension
@@ -130,6 +130,6 @@ public interface MutableSplat extends Splat
      * @param dimension The dimension
      * @param v The value
      */
-    void setShZ(int dimension, float v);
+    void setShZ(int dimension, double v);
 
 }

--- a/jsplat/src/main/java/de/javagl/jsplat/Splat.java
+++ b/jsplat/src/main/java/de/javagl/jsplat/Splat.java
@@ -36,77 +36,77 @@ public interface Splat
      * 
      * @return The value
      */
-    float getPositionX();
+    double getPositionX();
 
     /**
      * Returns the y-coordinate of the position
      * 
      * @return The value
      */
-    float getPositionY();
+    double getPositionY();
 
     /**
      * Returns the z-coordinate of the position
      * 
      * @return The value
      */
-    float getPositionZ();
+    double getPositionZ();
 
     /**
      * Returns the scale factor in x-direction
      * 
      * @return The value
      */
-    float getScaleX();
+    double getScaleX();
 
     /**
      * Returns the scale factor in y-direction
      * 
      * @return The value
      */
-    float getScaleY();
+    double getScaleY();
 
     /**
      * Returns the scale factor in z-direction
      * 
      * @return The value
      */
-    float getScaleZ();
+    double getScaleZ();
 
     /**
      * Returns the x-component of the rotation quaternion
      * 
      * @return The value
      */
-    float getRotationX();
+    double getRotationX();
 
     /**
      * Returns the y-component of the rotation quaternion
      * 
      * @return The value
      */
-    float getRotationY();
+    double getRotationY();
 
     /**
      * Returns the z-component of the rotation quaternion
      * 
      * @return The value
      */
-    float getRotationZ();
+    double getRotationZ();
 
     /**
      * Returns the w-component of the rotation quaternion
      * 
      * @return The value
      */
-    float getRotationW();
+    double getRotationW();
 
     /**
      * Returns the opacity value
      * 
      * @return The value
      */
-    float getOpacity();
+    double getOpacity();
 
     /**
      * Returns the spherical harmonics degree
@@ -128,7 +128,7 @@ public interface Splat
      * @param dimension The dimension
      * @return The value
      */
-    float getShX(int dimension);
+    double getShX(int dimension);
 
     /**
      * Returns the y-component of the spherical harmonic for the given dimension
@@ -136,7 +136,7 @@ public interface Splat
      * @param dimension The dimension
      * @return The value
      */
-    float getShY(int dimension);
+    double getShY(int dimension);
 
     /**
      * Returns the z-component of the spherical harmonic for the given dimension
@@ -144,5 +144,5 @@ public interface Splat
      * @param dimension The dimension
      * @return The value
      */
-    float getShZ(int dimension);
+    double getShZ(int dimension);
 }

--- a/jsplat/src/main/java/de/javagl/jsplat/SplatDatas.java
+++ b/jsplat/src/main/java/de/javagl/jsplat/SplatDatas.java
@@ -141,9 +141,9 @@ public class SplatDatas
         int i = 0;
         for (Splat s : splats)
         {
-            b.put(i * 3 + 0, s.getPositionX());
-            b.put(i * 3 + 1, s.getPositionY());
-            b.put(i * 3 + 2, s.getPositionZ());
+            b.put(i * 3 + 0, (float)s.getPositionX());
+            b.put(i * 3 + 1, (float)s.getPositionY());
+            b.put(i * 3 + 2, (float)s.getPositionZ());
             i++;
         }
         return b;
@@ -176,9 +176,9 @@ public class SplatDatas
         int i = 0;
         for (Splat s : splats)
         {
-            b.put(i * 3 + 0, s.getScaleX());
-            b.put(i * 3 + 1, s.getScaleY());
-            b.put(i * 3 + 2, s.getScaleZ());
+            b.put(i * 3 + 0, (float)s.getScaleX());
+            b.put(i * 3 + 1, (float)s.getScaleY());
+            b.put(i * 3 + 2, (float)s.getScaleZ());
             i++;
         }
         return b;
@@ -246,10 +246,10 @@ public class SplatDatas
         int i = 0;
         for (Splat s : splats)
         {
-            b.put(i * 4 + 0, s.getRotationX());
-            b.put(i * 4 + 1, s.getRotationY());
-            b.put(i * 4 + 2, s.getRotationZ());
-            b.put(i * 4 + 3, s.getRotationW());
+            b.put(i * 4 + 0, (float)s.getRotationX());
+            b.put(i * 4 + 1, (float)s.getRotationY());
+            b.put(i * 4 + 2, (float)s.getRotationZ());
+            b.put(i * 4 + 3, (float)s.getRotationW());
             i++;
         }
         return b;
@@ -282,7 +282,7 @@ public class SplatDatas
         int i = 0;
         for (Splat s : splats)
         {
-            b.put(i, s.getOpacity());
+            b.put(i, (float)s.getOpacity());
             i++;
         }
         return b;
@@ -291,7 +291,7 @@ public class SplatDatas
     /**
      * Read the alpha values from the given splats and write them into the 
      * given target buffer. The alpha values are the {@link Splat#getOpacity()}
-     * values, transformed with {@link Splats#opacityToAlpha(float)}.
+     * values, transformed with {@link Splats#opacityToAlpha(double)}.
      * 
      * The position of the given buffer will not be modified.
      * 
@@ -316,9 +316,9 @@ public class SplatDatas
         int i = 0;
         for (Splat s : splats)
         {
-            float opacity = s.getOpacity();
-            float alpha = Splats.opacityToAlpha(opacity);
-            b.put(i, alpha);
+            double opacity = s.getOpacity();
+            double alpha = Splats.opacityToAlpha(opacity);
+            b.put(i, (float)alpha);
             i++;
         }
         return b;
@@ -354,9 +354,9 @@ public class SplatDatas
         int i = 0;
         for (Splat s : splats)
         {
-            b.put(i * 3 + 0, s.getShX(index));
-            b.put(i * 3 + 1, s.getShY(index));
-            b.put(i * 3 + 2, s.getShZ(index));
+            b.put(i * 3 + 0, (float)s.getShX(index));
+            b.put(i * 3 + 1, (float)s.getShY(index));
+            b.put(i * 3 + 2, (float)s.getShZ(index));
             i++;
         }
         return b;
@@ -393,9 +393,9 @@ public class SplatDatas
         {
             for (int d = 0; d < shDimensions; d++)
             {
-                b.put(((i * shDimensions) + d) * 3 + 0, s.getShX(d));
-                b.put(((i * shDimensions) + d) * 3 + 1, s.getShY(d));
-                b.put(((i * shDimensions) + d) * 3 + 2, s.getShZ(d));
+                b.put(((i * shDimensions) + d) * 3 + 0, (float)s.getShX(d));
+                b.put(((i * shDimensions) + d) * 3 + 1, (float)s.getShY(d));
+                b.put(((i * shDimensions) + d) * 3 + 2, (float)s.getShZ(d));
             }
             i++;
         }
@@ -507,8 +507,8 @@ public class SplatDatas
     /**
      * Write the alpha values from the given buffer with
      * <code>splats.size()</code> elements into the given splats. The alpha
-     * values are transformed with {@link Splats#alphaToOpacity(float)} before
-     * assigning them as the {@link MutableSplat#setOpacity(float)} of the
+     * values are transformed with {@link Splats#alphaToOpacity(double)} before
+     * assigning them as the {@link MutableSplat#setOpacity(double)} of the
      * splats.
      * 
      * @param b The buffer
@@ -520,8 +520,8 @@ public class SplatDatas
         int i = 0;
         for (MutableSplat s : splats)
         {
-            float alpha = b.get(i);
-            float opacity = Splats.alphaToOpacity(alpha);
+            double alpha = b.get(i);
+            double opacity = Splats.alphaToOpacity(alpha);
             s.setOpacity(opacity);
             i++;
         }

--- a/jsplat/src/main/java/de/javagl/jsplat/Splats.java
+++ b/jsplat/src/main/java/de/javagl/jsplat/Splats.java
@@ -94,20 +94,20 @@ public class Splats
     {
         StringBuilder sb = new StringBuilder();
 
-        float px = splat.getPositionX();
-        float py = splat.getPositionY();
-        float pz = splat.getPositionZ();
+        double px = splat.getPositionX();
+        double py = splat.getPositionY();
+        double pz = splat.getPositionZ();
 
-        float sx = splat.getScaleX();
-        float sy = splat.getScaleY();
-        float sz = splat.getScaleZ();
+        double sx = splat.getScaleX();
+        double sy = splat.getScaleY();
+        double sz = splat.getScaleZ();
 
-        float rx = splat.getRotationX();
-        float ry = splat.getRotationY();
-        float rz = splat.getRotationZ();
-        float rw = splat.getRotationW();
+        double rx = splat.getRotationX();
+        double ry = splat.getRotationY();
+        double rz = splat.getRotationZ();
+        double rw = splat.getRotationW();
 
-        float o = splat.getOpacity();
+        double o = splat.getOpacity();
 
         String separator = "\n";
 
@@ -124,9 +124,9 @@ public class Splats
         int dimensions = splat.getShDimensions();
         for (int d = 0; d < dimensions; d++)
         {
-            float shx = splat.getShX(d);
-            float shy = splat.getShY(d);
-            float shz = splat.getShZ(d);
+            double shx = splat.getShX(d);
+            double shy = splat.getShY(d);
+            double shz = splat.getShZ(d);
             String shs = "sh" + d + "=(" + shx + "," + shy + "," + shz + ")";
             sb.append(shs).append(separator);
         }
@@ -214,9 +214,9 @@ public class Splats
      * @param dc The coefficient
      * @return The color value
      */
-    public static float directCurrentToColor(float dc)
+    public static double directCurrentToColor(double dc)
     {
-        float f = (float) (0.5 + SH_C0 * dc);
+        double f = 0.5 + SH_C0 * dc;
         return clamp(f);
     }
 
@@ -228,9 +228,9 @@ public class Splats
      * @param c The color value
      * @return The coefficient
      */
-    public static float colorToDirectCurrent(float c)
+    public static double colorToDirectCurrent(double c)
     {
-        float dc = (float) ((c - 0.5) / SH_C0);
+        double dc = (c - 0.5) / SH_C0;
         return dc;
     }
 
@@ -241,9 +241,9 @@ public class Splats
      * @param v The opacity
      * @return The alpha value
      */
-    public static float opacityToAlpha(float v)
+    public static double opacityToAlpha(double v)
     {
-        float alpha = (float) (1.0 / (1.0 + Math.exp(-v)));
+        double alpha = 1.0 / (1.0 + Math.exp(-v));
         return clamp(alpha);
     }
 
@@ -259,7 +259,7 @@ public class Splats
      * @param a The alpha value
      * @return The opacity value
      */
-    public static float alphaToOpacity(float a)
+    public static double alphaToOpacity(double a)
     {
         // This is to avoid infinity, but pick a value that
         // results in 255 or 0 during the inverse operation
@@ -271,7 +271,7 @@ public class Splats
         {
             return -20.0f;
         }
-        float opacity = (float) -Math.log(1.0f / a - 1.0);
+        double opacity = -Math.log(1.0f / a - 1.0);
         return opacity;
     }
 
@@ -281,7 +281,7 @@ public class Splats
      * @param f The value
      * @return The result
      */
-    private static float clamp(float f)
+    private static double clamp(double f)
     {
         if (f < 0.0f)
         {
@@ -379,7 +379,7 @@ public class Splats
      * @return The result
      */
     public static boolean equalsEpsilon(List<? extends Splat> sas,
-        List<? extends Splat> sbs, float epsilon)
+        List<? extends Splat> sbs, double epsilon)
     {
         if (sas.size() != sbs.size())
         {
@@ -413,7 +413,7 @@ public class Splats
      * @param epsilon The epsilon
      * @return The result
      */
-    public static boolean equalsEpsilon(Splat sa, Splat sb, float epsilon)
+    public static boolean equalsEpsilon(Splat sa, Splat sb, double epsilon)
     {
         int dimensionsA = sa.getShDimensions();
         int dimensionsB = sb.getShDimensions();
@@ -455,29 +455,29 @@ public class Splats
         // their dot product is +1.0 or -1.0. The quaternions should
         // be rotation quaternions (i.e. normalized), but this is not
         // ensured in general, so they are normalized here.
-        float ax = sa.getRotationX();
-        float ay = sa.getRotationY();
-        float az = sa.getRotationZ();
-        float aw = sa.getRotationW();
-        float aLenSquared = ax * ax + ay * ay + az * az + aw * aw;
-        float aInvLen = 1.0f / (float)Math.sqrt(aLenSquared);
-        float anx = ax * aInvLen; 
-        float any = ay * aInvLen; 
-        float anz = az * aInvLen; 
-        float anw = aw * aInvLen; 
+        double ax = sa.getRotationX();
+        double ay = sa.getRotationY();
+        double az = sa.getRotationZ();
+        double aw = sa.getRotationW();
+        double aLenSquared = ax * ax + ay * ay + az * az + aw * aw;
+        double aInvLen = 1.0f / Math.sqrt(aLenSquared);
+        double anx = ax * aInvLen; 
+        double any = ay * aInvLen; 
+        double anz = az * aInvLen; 
+        double anw = aw * aInvLen; 
         
-        float bx = sb.getRotationX();
-        float by = sb.getRotationY();
-        float bz = sb.getRotationZ();
-        float bw = sb.getRotationW();
-        float bLenSquared = bx * bx + by * by + bz * bz + bw * bw;
-        float bInvLen = 1.0f / (float)Math.sqrt(bLenSquared);
-        float bnx = bx * bInvLen; 
-        float bny = by * bInvLen; 
-        float bnz = bz * bInvLen; 
-        float bnw = bw * bInvLen; 
+        double bx = sb.getRotationX();
+        double by = sb.getRotationY();
+        double bz = sb.getRotationZ();
+        double bw = sb.getRotationW();
+        double bLenSquared = bx * bx + by * by + bz * bz + bw * bw;
+        double bInvLen = 1.0f / Math.sqrt(bLenSquared);
+        double bnx = bx * bInvLen; 
+        double bny = by * bInvLen; 
+        double bnz = bz * bInvLen; 
+        double bnw = bw * bInvLen; 
         
-        float dot = anx * bnx + any * bny + anz * bnz + anw * bnw;
+        double dot = anx * bnx + any * bny + anz * bnz + anw * bnw;
         if (Math.abs(Math.abs(dot) - 1.0f) > epsilon)
         {
             return false;
@@ -521,7 +521,7 @@ public class Splats
      * @param epsilon The epsilon
      * @return The result
      */
-    public static boolean strictEqualsEpsilon(Splat sa, Splat sb, float epsilon)
+    public static boolean strictEqualsEpsilon(Splat sa, Splat sb, double epsilon)
     {
         int dimensionsA = sa.getShDimensions();
         int dimensionsB = sb.getShDimensions();
@@ -609,15 +609,15 @@ public class Splats
      * @param epsilon The relative epsilon
      * @return Whether they are equal
      */
-    private static boolean equalsEpsilon(float a, float b, float epsilon)
+    private static boolean equalsEpsilon(double a, double b, double epsilon)
     {
-        float d = Math.abs(a - b);
+        double d = Math.abs(a - b);
         if (d < epsilon)
         {
             return true;
         }
-        float aa = Math.abs(a);
-        float ab = Math.abs(b);
+        double aa = Math.abs(a);
+        double ab = Math.abs(b);
         if (aa < ab)
         {
             return d <= ab * epsilon;

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 	<modules>
 		<module>jsplat</module>
 		<module>jsplat-processing</module>
+		<module>jsplat-simplification</module>
 		<module>jsplat-io-gsplat</module>
 		<module>jsplat-io-ply</module>
 		<module>jsplat-io-spz</module>


### PR DESCRIPTION
Adds a project containing basic simplification functionality for Gaussian splats.

The "core" of the simplification (i.e. the classes in `de.javagl.jsplat.simplification.incremental.nanogs`) have been ported from https://github.com/saliteta/NanoGS . This simplification package is therefore **not** distributed under the MIT license, but under the [CC BY-NC 4.0 license](https://github.com/javagl/JSplat/blob/a80ea35d45269c61ac76f1a63b213142690cf9af/jsplat-simplification/NanoGS-LICENSE.txt) to comply with the NanoGS licensing.
 
<img width="747" height="494" alt="JSplat simplify" src="https://github.com/user-attachments/assets/229169f3-be0b-474e-b9a7-b7f83d872dcf" />

